### PR TITLE
Import oidc package to allow for OIDC authentication.

### DIFF
--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 


### PR DESCRIPTION
Closes #26

I have tested this against a handful of clusters that use OIDC auth and it seems to allow me to auth and query using steampipe.