### PR TITLE
Added column template kubernetes_stateful_set table

### DIFF
--- a/kubernetes/table_kubernetes_stateful_set.go
+++ b/kubernetes/table_kubernetes_stateful_set.go
@@ -97,6 +97,12 @@ func tableKubernetesStatefulSet(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("Status.Conditions"),
 			},
 			{
+				Name:        "template",
+				Type:        proto.ColumnType_JSON,
+				Description: "Template is the object that describes the pod that will be created if insufficient replicas are detected.",
+				Transform:   transform.FromField("Spec.Template"),
+			},
+			{
 				Name:        "update_strategy",
 				Type:        proto.ColumnType_JSON,
 				Description: "Indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.",


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select jsonb_pretty(template -> 'spec' -> 'containers') from kubernetes_stateful_set
+-----------------------------------------------------------+
| jsonb_pretty                                              |
+-----------------------------------------------------------+
| [                                                         |
|     {                                                     |
|         "name": "nginx",                                  |
|         "image": "k8s.gcr.io/nginx-slim:0.8",             |
|         "ports": [                                        |
|             {                                             |
|                 "name": "web",                            |
|                 "protocol": "TCP",                        |
|                 "containerPort": 80                       |
|             }                                             |
|         ],                                                |
|         "resources": {                                    |
|         },                                                |
|         "volumeMounts": [                                 |
|             {                                             |
|                 "name": "www",                            |
|                 "mountPath": "/usr/share/nginx/html"      |
|             }                                             |
|         ],                                                |
|         "imagePullPolicy": "IfNotPresent",                |
|         "terminationMessagePath": "/dev/termination-log", |
|         "terminationMessagePolicy": "File"                |
|     }                                                     |
| ]                                                         |
+-----------------------------------------------------------+


> select
  -- Required Columns
  uid as resource,
  case
    when c -> 'livenessProbe' is not null then 'ok'
    else 'alarm'
  end as status,
  case
    when c -> 'livenessProbe' is not null then c ->> 'name' || ' has liveness probe.'
    else c ->> 'name' || ' does not have liveness probe.'
  end as reason,
  -- Additional Dimensions
  name as pod_name,
  namespace,
  context_name
from
  kubernetes_stateful_set,
  jsonb_array_elements(template -> 'spec' -> 'containers') as c;
+--------------------------------------+--------+-------------------------------------+----------+-----------+----------------------------------------+
| resource                             | status | reason                              | pod_name | namespace | context_name                           |
+--------------------------------------+--------+-------------------------------------+----------+-----------+----------------------------------------+
| 8a83bcf0-1375-4ff4-b0d3-9ad55fba5779 | alarm  | nginx does not have liveness probe. | web      | default   | gke_parker-aaa_us-central1-c_cluster-1 |
+--------------------------------------+--------+-------------------------------------+----------+-----------+----------------------------------------+
```
</details>
