### PR TITLE
Import azure package to allow for azure authentication

### DIFF
--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 


### PR DESCRIPTION
Adding azure authentication to get authentication that works with AzureAD OIDC working.
I tested on about 30 clusters I have running locally. Before the change I was getting the below error.

This corrects the error when logging in with AzureAD auth
Error: no Auth Provider found for name "azure" (SQLSTATE HV000)

Let me know if there is anything else you would like me to test.
