### PR TITLE
Add column selector_query to kubernetes_* tables and add optional key column selector_search to kubernetes_pod table. Closes #63

### DIFF
--- a/kubernetes/table_kubernetes_daemonset.go
+++ b/kubernetes/table_kubernetes_daemonset.go
@@ -38,6 +38,12 @@ func tableKubernetesDaemonset(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("Spec.RevisionHistoryLimit"),
 			},
 			{
+				Name:        "selector_query",
+				Type:        proto.ColumnType_STRING,
+				Description: "A query string representation of the selector.",
+				Transform:   transform.FromField("Spec.Selector").Transform(labelSelectorToString),
+			},
+			{
 				Name:        "selector",
 				Type:        proto.ColumnType_JSON,
 				Description: "A label query over pods that are managed by the daemon set.",

--- a/kubernetes/table_kubernetes_deployment.go
+++ b/kubernetes/table_kubernetes_deployment.go
@@ -32,6 +32,12 @@ func tableKubernetesDeployment(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("Spec.Replicas"),
 			},
 			{
+				Name:        "selector_query",
+				Type:        proto.ColumnType_STRING,
+				Description: "A query string representation of the selector.",
+				Transform:   transform.FromField("Spec.Selector").Transform(labelSelectorToString),
+			},
+			{
 				Name:        "selector",
 				Type:        proto.ColumnType_JSON,
 				Description: " Label selector for pods. A label selector is a label query over a set of resources.",

--- a/kubernetes/table_kubernetes_job.go
+++ b/kubernetes/table_kubernetes_job.go
@@ -49,12 +49,6 @@ func tableKubernetesJob(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("Spec.BackoffLimit"),
 			},
 			{
-				Name:        "selector",
-				Type:        proto.ColumnType_JSON,
-				Description: "A label query over pods that should match the pod count.",
-				Transform:   transform.FromField("Spec.Selector"),
-			},
-			{
 				Name:        "manual_selector",
 				Type:        proto.ColumnType_BOOL,
 				Description: "ManualSelector controls generation of pod labels and pod selectors. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.",
@@ -65,6 +59,18 @@ func tableKubernetesJob(ctx context.Context) *plugin.Table {
 				Type:        proto.ColumnType_INT,
 				Description: "limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted.",
 				Transform:   transform.FromField("Spec.TTLSecondsAfterFinished"),
+			},
+			{
+				Name:        "selector_query",
+				Type:        proto.ColumnType_STRING,
+				Description: "A query string representation of the selector.",
+				Transform:   transform.FromField("Spec.Selector").Transform(labelSelectorToString),
+			},
+			{
+				Name:        "selector",
+				Type:        proto.ColumnType_JSON,
+				Description: "A label query over pods that should match the pod count.",
+				Transform:   transform.FromField("Spec.Selector"),
 			},
 			{
 				Name:        "template",

--- a/kubernetes/table_kubernetes_pod.go
+++ b/kubernetes/table_kubernetes_pod.go
@@ -22,16 +22,16 @@ func tableKubernetesPod(ctx context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listK8sPods,
 			KeyColumns: []*plugin.KeyColumn{
-				{Name: "label_selector", Require: plugin.Optional},
+				{Name: "selector_search", Require: plugin.Optional, CacheMatch: "exact"},
 			},
 		},
 		Columns: k8sCommonColumns([]*plugin.Column{
 			//// PodSpec Columns
 			{
-				Name:        "label_selector",
+				Name:        "selector_search",
 				Type:        proto.ColumnType_STRING,
-				Description: "A selector to restrict the list of returned objects by their labels.",
-				Transform:   transform.FromQual("label_selector"),
+				Description: "A label selector string to restrict the list of returned objects by their labels.",
+				Transform:   transform.FromQual("selector_search"),
 			},
 			{
 				Name:        "volumes",
@@ -421,11 +421,8 @@ func listK8sPods(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	}
 
 	option := metav1.ListOptions{}
-
-	labelSelector := d.KeyColumnQuals["label_selector"].GetStringValue()
-
-	if labelSelector != "" {
-		option.LabelSelector = labelSelector
+	if d.KeyColumnQuals["selector_search"] != nil {
+		option.LabelSelector = d.KeyColumnQuals["selector_search"].GetStringValue()
 	}
 
 	pods, err := clientset.CoreV1().Pods("").List(ctx, option)

--- a/kubernetes/table_kubernetes_replicaset.go
+++ b/kubernetes/table_kubernetes_replicaset.go
@@ -38,6 +38,12 @@ func tableKubernetesReplicaSet(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("Spec.MinReadySeconds"),
 			},
 			{
+				Name:        "selector_query",
+				Type:        proto.ColumnType_STRING,
+				Description: "A query string representation of the selector.",
+				Transform:   transform.FromField("Spec.Selector").Transform(labelSelectorToString),
+			},
+			{
 				Name:        "selector",
 				Type:        proto.ColumnType_JSON,
 				Description: "Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set.",

--- a/kubernetes/table_kubernetes_replication_controller.go
+++ b/kubernetes/table_kubernetes_replication_controller.go
@@ -38,6 +38,12 @@ func tableKubernetesReplicaController(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("Spec.MinReadySeconds"),
 			},
 			{
+				Name:        "selector_query",
+				Type:        proto.ColumnType_STRING,
+				Description: "A query string representation of the selector.",
+				Transform:   transform.FromField("Spec.Selector").Transform(labelSelectorToString),
+			},
+			{
 				Name:        "selector",
 				Type:        proto.ColumnType_JSON,
 				Description: "Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set.",

--- a/kubernetes/table_kubernetes_service.go
+++ b/kubernetes/table_kubernetes_service.go
@@ -129,7 +129,7 @@ func tableKubernetesService(ctx context.Context) *plugin.Table {
 			{
 				Name:        "selector_query",
 				Type:        proto.ColumnType_STRING,
-				Description: "Route service traffic to pods with label keys and values matching this selector. String format representation.",
+				Description: "A query string representation of the selector.",
 				Transform:   transform.FromField("Spec.Selector").Transform(selectorMapToString),
 			},
 			{

--- a/kubernetes/table_kubernetes_service.go
+++ b/kubernetes/table_kubernetes_service.go
@@ -5,7 +5,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
@@ -80,12 +79,6 @@ func tableKubernetesService(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("Spec.PublishNotReadyAddresses"),
 			},
 			{
-				Name:        "selector_string_format",
-				Type:        proto.ColumnType_STRING,
-				Description: "Route service traffic to pods with label keys and values matching this selector. String format representation.",
-				Transform:   transform.From(selectorToString),
-			},
-			{
 				Name:        "session_affinity",
 				Type:        proto.ColumnType_STRING,
 				Description: "Supports 'ClientIP' and 'None'. Used to maintain session affinity.",
@@ -132,6 +125,12 @@ func tableKubernetesService(ctx context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Description: "A list of ports that are exposed by this service.",
 				Transform:   transform.FromField("Spec.Ports"),
+			},
+			{
+				Name:        "selector_query",
+				Type:        proto.ColumnType_STRING,
+				Description: "Route service traffic to pods with label keys and values matching this selector. String format representation.",
+				Transform:   transform.FromField("Spec.Selector").Transform(selectorMapToString),
 			},
 			{
 				Name:        "selector",
@@ -211,14 +210,4 @@ func getK8sService(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 func transformServiceTags(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	obj := d.HydrateItem.(v1.Service)
 	return mergeTags(obj.Labels, obj.Annotations), nil
-}
-
-func selectorToString(_ context.Context, d *transform.TransformData) (interface{}, error) {
-	obj := d.HydrateItem.(v1.Service)
-	if obj.Spec.Selector == nil {
-		return nil, nil
-	}
-	selector := labels.SelectorFromSet(obj.Spec.Selector).String()
-
-	return selector, nil
 }

--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -230,7 +230,6 @@ func selectorMapToString(ctx context.Context, d *transform.TransformData) (inter
 	selector_map := d.Value.(map[string]string)
 
 	if len(selector_map) == 0 {
-		logger.Warn("selectorMapToString", "!!! selector is empty")
 		return nil, nil
 	}
 

--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
@@ -205,6 +206,37 @@ func v1TimeToRFC3339(_ context.Context, d *transform.TransformData) (interface{}
 	default:
 		return nil, fmt.Errorf("invalid time format %T! ", v)
 	}
+}
+
+func labelSelectorToString(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	if d.Value == nil {
+		return nil, nil
+	}
+
+	selector := d.Value.(*v1.LabelSelector)
+
+	ss, err := v1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	return ss.String(), nil
+}
+
+func selectorMapToString(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("selectorMapToString")
+
+	selector_map := d.Value.(map[string]string)
+
+	if len(selector_map) == 0 {
+		logger.Warn("selectorMapToString", "!!! selector is empty")
+		return nil, nil
+	}
+
+	selector_string := labels.SelectorFromSet(selector_map).String()
+
+	return selector_string, nil
 }
 
 //// Other Utility functions


### PR DESCRIPTION
# Column selector_query added in below tables
- kubernetes_daemonset
- kubernetes_deployment
- kubernetes_job
- kubernetes_replicaset
- kubernetes_job
- kubernetes_replication_controller

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from kubernetes_pod where selector_search in (select selector_query from kubernetes_daemonset)
+-------------------------+-------------+--------------------------------------+-------------------------------------------------------+--------------------------------------------------------------------
| name                    | namespace   | uid                                  | selector_search                                       | volumes                                                            
+-------------------------+-------------+--------------------------------------+-------------------------------------------------------+--------------------------------------------------------------------
| fluentbit-gke-7wldf     | kube-system | 89b7b452-714c-4bef-92f1-eca3622f31a6 | component=fluentbit-gke,k8s-app=fluentbit-gke         | [{"hostPath":{"path":"/var/run/google-fluentbit/pos-files","type":"
|                         |             |                                      |                                                       |                                                                    
| gke-metrics-agent-l2895 | kube-system | 0b37ab72-a044-428e-b9d6-08d93dd5467f | component=gke-metrics-agent,k8s-app=gke-metrics-agent | [{"configMap":{"defaultMode":420,"items":[{"key":"gke-metrics-agent
|                         |             |                                      |                                                       |                                                                    
| pdcsi-node-tn6df        | kube-system | 34c3e74a-2400-4b04-893d-ddb8c96fda0e | k8s-app=gcp-compute-persistent-disk-csi-driver        | [{"hostPath":{"path":"/var/lib/kubelet/plugins_registry/","type":"D
|                         |             |                                      |                                                       |                                                                    
+-------------------------+-------------+--------------------------------------+-------------------------------------------------------+--------------------------------------------------------------------
> select * from kubernetes_pod where selector_search in (select selector_query from kubernetes_deployment)
+------------------------------------------------+-------------+--------------------------------------+---------------------------------------+-------------------------------------------------------------
| name                                           | namespace   | uid                                  | selector_search                       | volumes                                                     
+------------------------------------------------+-------------+--------------------------------------+---------------------------------------+-------------------------------------------------------------
| konnectivity-agent-67f549dc86-m5kxp            | kube-system | f3428e8d-3bc6-4fe9-abd2-860dc0748b0a | k8s-app=konnectivity-agent            | [{"name":"konnectivity-agent-token","projected":{"defaultMod
|                                                |             |                                      |                                       |                                                             
| kube-dns-697dc8fc8b-pg4vr                      | kube-system | ccda5ae4-07c2-41e9-9dcd-5c71ac160237 | k8s-app=kube-dns                      | [{"configMap":{"defaultMode":420,"name":"kube-dns","optional
|                                                |             |                                      |                                       |                                                             
|                                                |             |                                      |                                       |                                                             
|                                                |             |                                      |                                       |                                                             
|                                                |             |                                      |                                       |                                                             
| kube-dns-autoscaler-844c9d9448-t8z4v           | kube-system | 0ffb3c73-b92c-45e9-b4b9-952a5e8d1c3f | k8s-app=kube-dns-autoscaler           | [{"name":"kube-api-access-bs8b2","projected":{"defaultMode":
| l7-default-backend-69fb9fd9f9-zmz65            | kube-system | 6844bf00-bcac-4a3b-8230-54a1eeb21063 | k8s-app=glbc                          | [{"name":"kube-api-access-2tbdf","projected":{"defaultMode":
| konnectivity-agent-autoscaler-5c49cb58bb-cldpv | kube-system | bca77a2f-3973-4e30-8c35-e505b6f2ac78 | k8s-app=konnectivity-agent-autoscaler | [{"name":"kube-api-access-fd6xq","projected":{"defaultMode":
| event-exporter-gke-5479fd58c8-rrzv2            | kube-system | 7d73a3ed-3ed7-4a0a-8846-cb720f3f406e | k8s-app=event-exporter                | [{"hostPath":{"path":"/etc/ssl/certs","type":""},"name":"ssl
|                                                |             |                                      |                                       |                                                             
| metrics-server-v0.4.5-bbb794dcc-9k5qc          | kube-system | 48bca893-42ff-44b9-81c9-f4116a42119f | k8s-app=metrics-server,version=v0.4.5 | [{"configMap":{"defaultMode":420,"name":"metrics-server-conf
|                                                |             |                                      |                                       |                                                             
+------------------------------------------------+-------------+--------------------------------------+---------------------------------------+-------------------------------------------------------------
> select * from kubernetes_pod where selector_search in (select selector_query from kubernetes_replicaset)
+------------------------------------------------+-------------+--------------------------------------+--------------------------------------------------------------------+--------------------------------
| name                                           | namespace   | uid                                  | selector_search                                                    | volumes                        
+------------------------------------------------+-------------+--------------------------------------+--------------------------------------------------------------------+--------------------------------
| metrics-server-v0.4.5-bbb794dcc-9k5qc          | kube-system | 48bca893-42ff-44b9-81c9-f4116a42119f | k8s-app=metrics-server,pod-template-hash=bbb794dcc,version=v0.4.5  | [{"configMap":{"defaultMode":42
|                                                |             |                                      |                                                                    |                                
| event-exporter-gke-5479fd58c8-rrzv2            | kube-system | 7d73a3ed-3ed7-4a0a-8846-cb720f3f406e | k8s-app=event-exporter,pod-template-hash=5479fd58c8                | [{"hostPath":{"path":"/etc/ssl/
|                                                |             |                                      |                                                                    |                                
| kube-dns-697dc8fc8b-pg4vr                      | kube-system | ccda5ae4-07c2-41e9-9dcd-5c71ac160237 | k8s-app=kube-dns,pod-template-hash=697dc8fc8b                      | [{"configMap":{"defaultMode":42
|                                                |             |                                      |                                                                    |                                
|                                                |             |                                      |                                                                    |                                
|                                                |             |                                      |                                                                    |                                
|                                                |             |                                      |                                                                    |                                
| konnectivity-agent-67f549dc86-m5kxp            | kube-system | f3428e8d-3bc6-4fe9-abd2-860dc0748b0a | k8s-app=konnectivity-agent,pod-template-hash=67f549dc86            | [{"name":"konnectivity-agent-to
|                                                |             |                                      |                                                                    |                                
| kube-dns-autoscaler-844c9d9448-t8z4v           | kube-system | 0ffb3c73-b92c-45e9-b4b9-952a5e8d1c3f | k8s-app=kube-dns-autoscaler,pod-template-hash=844c9d9448           | [{"name":"kube-api-access-bs8b2
| konnectivity-agent-autoscaler-5c49cb58bb-cldpv | kube-system | bca77a2f-3973-4e30-8c35-e505b6f2ac78 | k8s-app=konnectivity-agent-autoscaler,pod-template-hash=5c49cb58bb | [{"name":"kube-api-access-fd6xq
| l7-default-backend-69fb9fd9f9-zmz65            | kube-system | 6844bf00-bcac-4a3b-8230-54a1eeb21063 | k8s-app=glbc,pod-template-hash=69fb9fd9f9                          | [{"name":"kube-api-access-2tbdf
+------------------------------------------------+-------------+--------------------------------------+--------------------------------------------------------------------+--------------------------------
> select * from kubernetes_pod where selector_search in (select selector_query from kubernetes_replication_controller)
+------+-----------+-----+-----------------+---------+------------+----------------------+-----------------+----------------+----------------------------------+-------------------------+------------+-----
| name | namespace | uid | selector_search | volumes | containers | ephemeral_containers | init_containers | restart_policy | termination_grace_period_seconds | active_deadline_seconds | dns_policy | node
+------+-----------+-----+-----------------+---------+------------+----------------------+-----------------+----------------+----------------------------------+-------------------------+------------+-----
+------+-----------+-----+-----------------+---------+------------+----------------------+-----------------+----------------+----------------------------------+-------------------------+------------+-----
> select * from kubernetes_pod where selector_search in (select selector_query from kubernetes_job)
+------+-----------+-----+-----------------+---------+------------+----------------------+-----------------+----------------+----------------------------------+-------------------------+------------+-----
| name | namespace | uid | selector_search | volumes | containers | ephemeral_containers | init_containers | restart_policy | termination_grace_period_seconds | active_deadline_seconds | dns_policy | node
+------+-----------+-----+-----------------+---------+------------+----------------------+-----------------+----------------+----------------------------------+-------------------------+------------+-----
+------+-----------+-----+-----------------+---------+------------+----------------------+-----------------+----------------+----------------------------------+-------------------------+------------+-----

```
</details>
