### PR TITLE
feat: add kubernetes_horizontal_pod_autoscaler table

### DIFF
--- a/docs/tables/kubernetes_horizontal_pod_autoscaler.md
+++ b/docs/tables/kubernetes_horizontal_pod_autoscaler.md
@@ -1,0 +1,36 @@
+# Table: kubernetes_horizontal_pod_autoscaler
+
+Kubernetes  HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
+
+## Examples
+
+### Basic Info
+
+```sql
+select
+  name,
+  namespace,
+  min_replicas,
+  max_replicas,
+  current_replicas,
+  desired_replicas 
+from
+  kubernetes_horizontal_pod_autoscaler;
+```
+
+### Get list of HPA metrics configurations
+
+```sql
+select
+  name,
+  namespace,
+  min_replicas,
+  max_replicas,
+  current_replicas,
+  desired_replicas,
+  jsonb_array_elements(metrics) as metrics,
+  jsonb_array_elements(current_metrics) as current_metrics,
+  conditions 
+from
+  kubernetes_horizontal_pod_autoscaler;
+```

--- a/kubernetes/plugin.go
+++ b/kubernetes/plugin.go
@@ -37,6 +37,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"kubernetes_deployment":                 tableKubernetesDeployment(ctx),
 			"kubernetes_endpoint":                   tableKubernetesEndpoints(ctx),
 			"kubernetes_endpoint_slice":             tableKubernetesEndpointSlice(ctx),
+			"kubernetes_horizontal_pod_autoscaler":  tableKubernetesHorizontalPodAutoscaler(ctx),
 			"kubernetes_ingress":                    tableKubernetesIngress(ctx),
 			"kubernetes_job":                        tableKubernetesJob(ctx),
 			"kubernetes_limit_range":                tableKubernetesLimitRange(ctx),

--- a/kubernetes/table_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/table_kubernetes_horizontal_pod_autoscaler.go
@@ -1,0 +1,235 @@
+package kubernetes
+
+import (
+	"context"
+	"k8s.io/api/autoscaling/v2beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+
+	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin/transform"
+)
+
+func tableKubernetesHorizontalPodAutoscaler(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name: "kubernetes_horizontal_pod_autoscaler",
+		Description: "Kubernetes  HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which " +
+			"automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified. " +
+			"This resource is created by clients",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AllColumns([]string{"name", "namespace"}),
+			Hydrate:    getK8sHpa,
+		},
+		List: &plugin.ListConfig{
+			Hydrate:    listK8sHpa,
+			KeyColumns: getCommonOptionalKeyQuals(),
+		},
+		Columns: k8sCommonColumns([]*plugin.Column{
+			//// HpaSpec Columns
+			{
+				Name: "scale_target_ref",
+				Type: proto.ColumnType_JSON,
+				Description: "horizontal pod autoscaler will learn the current resource consumption " +
+					"and will set the desired number of pods by using its Scale subresource.",
+				Transform: transform.FromField("Spec.ScaleTargetRef"),
+			},
+			{
+				Name: "min_replicas",
+				Type: proto.ColumnType_INT,
+				Description: "MinReplicas is the lower limit for the number of replicas to which the autoscaler " +
+					" can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the " +
+					" alpha feature gate HPAScaleToZero is enabled and at least one Object or External " +
+					" metric is configured.  Scaling is active as long as at least one metric value is " +
+					" available.",
+				Transform: transform.FromField("Spec.MinReplicas"),
+			},
+			{
+				Name: "max_replicas",
+				Type: proto.ColumnType_INT,
+				Description: "The Upper limit for the number of pods that can be set by the autoscaler. " +
+					"It cannot be smaller than MinReplicas.",
+				Transform: transform.FromField("Spec.MaxReplicas"),
+			},
+			{
+				Name: "metrics",
+				Type: proto.ColumnType_JSON,
+				Description: "Metrics contains the specifications for which to use to calculate the " +
+					" desired replica count (the maximum replica count across all metrics will " +
+					" be used).  The desired replica count is calculated multiplying the " +
+					" ratio between the target value and the current value by the current " +
+					" number of pods.  Ergo, metrics used must decrease as the pod count is " +
+					" increased, and vice-versa.  See the individual metric source types for " +
+					" more information about how each type of metric must respond. " +
+					" If not set, the default metric will be set to 80% average CPU utilization.",
+				Transform: transform.FromField("Spec.Metrics"),
+			},
+			{
+				Name: "scale_up_behavior",
+				Type: proto.ColumnType_JSON,
+				Description: "Behavior configures the scaling behavior of the target " +
+					"in both Up and Down directions (scaleUp and scaleDown fields respectively)." +
+					"If not set, the default value is the higher of: " +
+					"  * increase no more than 4 pods per 60 seconds " +
+					"  * double the number of pods per 60 seconds ",
+				Transform: transform.FromField("Spec.Behavior.ScaleUp"),
+			},
+			{
+				Name: "scale_down_behavior",
+				Type: proto.ColumnType_JSON,
+				Description: "Behavior configures the scaling behavior of the target " +
+					"in both Up and Down directions (scaleUp and scaleDown fields respectively)." +
+					"If not set, the default value is to allow to scale down to minReplicas pods, with a " +
+					"300 second stabilization window (i.e., the highest recommendation for the last 300sec is used).",
+				Transform: transform.FromField("Spec.Behavior.ScaleDown"),
+			},
+
+			//// HpaStatus Columns
+			{
+				Name:        "observed_generation",
+				Type:        proto.ColumnType_INT,
+				Description: "The most recent generation observed by this autoscaler.",
+				Transform:   transform.FromField("Status.ObservedGeneration"),
+			},
+			{
+				Name: "last_scale_time",
+				Type: proto.ColumnType_TIMESTAMP,
+				Description: "The last time the HorizontalPodAutoscaler scaled the number of pods; " +
+					"used by the autoscaler to control how often the number of pods is changed.",
+				Transform: transform.FromField("Status.LastScaleTime").Transform(v1TimeToRFC3339),
+			},
+			{
+				Name:        "current_replicas",
+				Type:        proto.ColumnType_INT,
+				Description: "The current number of replicas of pods managed by this autoscaler.",
+				Transform:   transform.FromField("Status.CurrentReplicas"),
+			},
+			{
+				Name:        "desired_replicas",
+				Type:        proto.ColumnType_INT,
+				Description: "The desired number of replicas of pods managed by this autoscaler.",
+				Transform:   transform.FromField("Status.DesiredReplicas"),
+			},
+			{
+				Name:        "current_metrics",
+				Type:        proto.ColumnType_JSON,
+				Description: "CurrentMetrics is the last read state of the metrics used by this autoscaler.",
+				Transform:   transform.FromField("Status.CurrentMetrics"),
+			},
+			{
+				Name: "conditions",
+				Type: proto.ColumnType_JSON,
+				Description: "Conditions is the set of conditions required for this autoscaler to scale its target, " +
+					"and indicates whether or not those conditions are met.",
+				Transform: transform.FromField("Status.Conditions"),
+			},
+
+			//// Steampipe Standard Columns
+			{
+				Name:        "title",
+				Type:        proto.ColumnType_STRING,
+				Description: ColumnDescriptionTitle,
+				Transform:   transform.FromField("Name"),
+			},
+			{
+				Name:        "tags",
+				Type:        proto.ColumnType_JSON,
+				Description: ColumnDescriptionTags,
+				Transform:   transform.From(transformHpaTags),
+			},
+		}),
+	}
+}
+
+//// HYDRATE FUNCTIONS
+
+func listK8sHpa(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("listK8sHpa")
+
+	clientset, err := GetNewClientset(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	input := metav1.ListOptions{
+		Limit: 500,
+	}
+
+	// Limiting the results
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < input.Limit {
+			if *limit < 1 {
+				input.Limit = 1
+			} else {
+				input.Limit = *limit
+			}
+		}
+	}
+
+	commonFieldSelectorValue := getCommonOptionalKeyQualsValueForFieldSelector(d)
+
+	if len(commonFieldSelectorValue) > 0 {
+		input.FieldSelector = strings.Join(commonFieldSelectorValue, ",")
+	}
+
+	var response *v2beta2.HorizontalPodAutoscalerList
+	pageLeft := true
+
+	for pageLeft {
+		response, err = clientset.AutoscalingV2beta2().HorizontalPodAutoscalers("").List(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+
+		if response.GetContinue() != "" {
+			input.Continue = response.Continue
+		} else {
+			pageLeft = false
+		}
+
+		for _, hpa := range response.Items {
+			d.StreamListItem(ctx, hpa)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func getK8sHpa(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("getK8sHpa")
+
+	clientset, err := GetNewClientset(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	name := d.KeyColumnQuals["name"].GetStringValue()
+	namespace := d.KeyColumnQuals["namespace"].GetStringValue()
+
+	// return if namespace or name is empty
+	if namespace == "" || name == "" {
+		return nil, nil
+	}
+
+	hpa, err := clientset.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil && !isNotFoundError(err) {
+		return nil, err
+	}
+
+	return *hpa, nil
+}
+
+////// TRANSFORM FUNCTIONS
+
+func transformHpaTags(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	obj := d.HydrateItem.(v2beta2.HorizontalPodAutoscaler)
+	return mergeTags(obj.Labels, obj.Annotations), nil
+}


### PR DESCRIPTION
# Description 

Add `kubernetes_horizontal_pod_autoscaler` table to kubernetes plugin, allowing list and get on hpa.

# Example query results
<details>
  <summary>Results</summary>
  
```
select
  name,
  namespace,
  min_replicas,
  max_replicas,
  current_replicas,
  desired_replicas,
  jsonb_array_elements(metrics) as metrics,
  jsonb_array_elements(current_metrics) as current_metrics,
  conditions 
from
  kubernetes_horizontal_pod_autoscaler;
```
</details>
