### PR TITLE
Add table kubernetes_event

### DIFF
--- a/docs/tables/kubernetes_event.md
+++ b/docs/tables/kubernetes_event.md
@@ -1,0 +1,38 @@
+# Table: kubernetes_event
+
+Event is a report of an event somewhere in the cluster. Events have a limited retention time and triggers and messages may evolve with time. Events should be treated as informative, best-effort, supplemental data.
+
+## Examples
+
+### Basic Info
+
+```sql
+select
+  namespace,
+  last_timestamp,
+  type,
+  reason,
+  concat(involved_object ->> 'kind', '/', involved_object ->> 'name') as object,
+  message
+from
+  kubernetes_event;
+```
+
+### List warning events by last timestamp
+
+```sql
+select
+  namespace,
+  last_timestamp,
+  type,
+  reason,
+  concat(involved_object ->> 'kind', '/', involved_object ->> 'name') as object,
+  message
+from
+  kubernetes_event
+where
+  type = 'Warning'
+order by
+  namespace,
+  last_timestamp;
+```

--- a/kubernetes/plugin.go
+++ b/kubernetes/plugin.go
@@ -37,6 +37,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"kubernetes_deployment":                 tableKubernetesDeployment(ctx),
 			"kubernetes_endpoint":                   tableKubernetesEndpoints(ctx),
 			"kubernetes_endpoint_slice":             tableKubernetesEndpointSlice(ctx),
+			"kubernetes_event":                      tableKubernetesEvent(ctx),
 			"kubernetes_horizontal_pod_autoscaler":  tableKubernetesHorizontalPodAutoscaler(ctx),
 			"kubernetes_ingress":                    tableKubernetesIngress(ctx),
 			"kubernetes_job":                        tableKubernetesJob(ctx),

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -116,7 +116,6 @@ func tableKubernetesEvent(ctx context.Context) *plugin.Table {
 //// HYDRATE FUNCTIONS
 
 func listK8sEvents(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	logger := plugin.Logger(ctx)
 	logger.Trace("listK8sEvents")
 
 	clientset, err := GetNewClientset(ctx, d)

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -120,6 +120,7 @@ func listK8sEvents(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 
 	clientset, err := GetNewClientset(ctx, d)
 	if err != nil {
+plugin.Logger(ctx).Error("listK8sEvents", "client_err", err)
 		return nil, err
 	}
 

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -111,7 +111,7 @@ func listK8sEvents(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 
 	clientset, err := GetNewClientset(ctx, d)
 	if err != nil {
-plugin.Logger(ctx).Error("listK8sEvents", "client_err", err)
+		plugin.Logger(ctx).Error("listK8sEvents", "client_err", err)
 		return nil, err
 	}
 
@@ -143,7 +143,7 @@ plugin.Logger(ctx).Error("listK8sEvents", "client_err", err)
 	for pageLeft {
 		response, err = clientset.CoreV1().Events("").List(ctx, input)
 		if err != nil {
-plugin.Logger(ctx).Error("listK8sEvents", "api_err", err)
+			plugin.Logger(ctx).Error("listK8sEvents", "api_err", err)
 			return nil, err
 		}
 
@@ -170,7 +170,7 @@ func getK8sEvent(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 
 	clientset, err := GetNewClientset(ctx, d)
 	if err != nil {
-plugin.Logger(ctx).Error("getK8sEvent", "client_err", err)
+		plugin.Logger(ctx).Error("getK8sEvent", "client_err", err)
 		return nil, err
 	}
 
@@ -184,7 +184,7 @@ plugin.Logger(ctx).Error("getK8sEvent", "client_err", err)
 
 	event, err := clientset.CoreV1().Events(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil && !isNotFoundError(err) {
-plugin.Logger(ctx).Error("getK8sEvent", "api_err", err)
+		plugin.Logger(ctx).Error("getK8sEvent", "api_err", err)
 		return nil, err
 	}
 

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -175,7 +175,6 @@ func listK8sEvents(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 }
 
 func getK8sEvent(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	logger := plugin.Logger(ctx)
 	logger.Trace("getK8sEvent")
 
 	clientset, err := GetNewClientset(ctx, d)

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -1,0 +1,200 @@
+package kubernetes
+
+import (
+	"context"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin/transform"
+)
+
+func tableKubernetesEvent(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "kubernetes_event",
+		Description: "Kubernetes Event is a report of an event somewhere in the cluster.",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AllColumns([]string{"name", "namespace"}),
+			Hydrate:    getK8sEvent,
+		},
+		List: &plugin.ListConfig{
+			Hydrate:    listK8sEvents,
+			KeyColumns: getCommonOptionalKeyQuals(),
+		},
+		Columns: k8sCommonColumns([]*plugin.Column{
+			{
+				Name:        "action",
+				Type:        proto.ColumnType_STRING,
+				Description: "What action was taken/failed with the regarding object.",
+				Transform:   transform.FromField("Action"),
+			},
+			{
+				Name:        "count",
+				Type:        proto.ColumnType_INT,
+				Description: "The number of times this event has occurred.",
+				Transform:   transform.FromField("Count"),
+			},
+			{
+				Name:        "event_time",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Description: "Time when this event was first observed.",
+				Transform:   transform.FromField("EventTime").Transform(v1MicroTimeToRFC3339),
+			},
+			{
+				Name:        "first_timestamp",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Description: "The time at which the event was first recorded.",
+				Transform:   transform.FromField("FirstTimestamp").Transform(v1TimeToRFC3339),
+			},
+			{
+				Name:        "involved_object",
+				Type:        proto.ColumnType_JSON,
+				Description: "The object that this event is about.",
+				Transform:   transform.FromField("InvolvedObject"),
+			},
+			{
+				Name:        "last_timestamp",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Description: "Time when this event was last observed.",
+				Transform:   transform.FromField("LastTimestamp").Transform(v1TimeToRFC3339),
+			},
+			{
+				Name:        "message",
+				Type:        proto.ColumnType_STRING,
+				Description: "A description of the status of this operation.",
+				Transform:   transform.FromField("Message"),
+			},
+			{
+				Name:        "reason",
+				Type:        proto.ColumnType_STRING,
+				Description: "The reason the transition into the object's current status.",
+				Transform:   transform.FromField("Reason"),
+			},
+			{
+				Name:        "related",
+				Type:        proto.ColumnType_JSON,
+				Description: "Optional secondary object for more complex actions.",
+				Transform:   transform.FromField("Related"),
+			},
+			{
+				Name:        "reporting_component",
+				Type:        proto.ColumnType_STRING,
+				Description: "Name of the controller that emitted this event.",
+				Transform:   transform.FromField("ReportingComponent"),
+			},
+			{
+				Name:        "reporting_instance",
+				Type:        proto.ColumnType_STRING,
+				Description: "ID of the controller instance.",
+				Transform:   transform.FromField("ReportingInstance"),
+			},
+			{
+				Name:        "series",
+				Type:        proto.ColumnType_JSON,
+				Description: "Data about the event series this event represents.",
+				Transform:   transform.FromField("Series"),
+			},
+			{
+				Name:        "source",
+				Type:        proto.ColumnType_JSON,
+				Description: "The component reporting this event.",
+				Transform:   transform.FromField("Source"),
+			},
+			{
+				Name:        "type",
+				Type:        proto.ColumnType_STRING,
+				Description: "Type of this event (Normal, Warning), new types could be added in the future.",
+				Transform:   transform.FromField("Type"),
+			},
+		}),
+	}
+}
+
+//// HYDRATE FUNCTIONS
+
+func listK8sEvents(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("listK8sEvents")
+
+	clientset, err := GetNewClientset(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	input := metav1.ListOptions{
+		Limit: 500,
+	}
+
+	// Limiting the results
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < input.Limit {
+			if *limit < 1 {
+				input.Limit = 1
+			} else {
+				input.Limit = *limit
+			}
+		}
+	}
+
+	commonFieldSelectorValue := getCommonOptionalKeyQualsValueForFieldSelector(d)
+
+	if len(commonFieldSelectorValue) > 0 {
+		input.FieldSelector = strings.Join(commonFieldSelectorValue, ",")
+	}
+
+	var response *v1.EventList
+	pageLeft := true
+
+	for pageLeft {
+		response, err = clientset.CoreV1().Events("").List(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+
+		if response.GetContinue() != "" {
+			input.Continue = response.Continue
+		} else {
+			pageLeft = false
+		}
+
+		for _, event := range response.Items {
+			d.StreamListItem(ctx, event)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func getK8sEvent(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("getK8sEvent")
+
+	clientset, err := GetNewClientset(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	name := d.KeyColumnQuals["name"].GetStringValue()
+	namespace := d.KeyColumnQuals["namespace"].GetStringValue()
+
+	// return if namespace or name is empty
+	if namespace == "" || name == "" {
+		return nil, nil
+	}
+
+	event, err := clientset.CoreV1().Events(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil && !isNotFoundError(err) {
+		return nil, err
+	}
+
+	return *event, nil
+}

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -193,6 +193,7 @@ func getK8sEvent(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 
 	event, err := clientset.CoreV1().Events(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil && !isNotFoundError(err) {
+plugin.Logger(ctx).Error("getK8sEvent", "api_err", err)
 		return nil, err
 	}
 

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -152,6 +152,7 @@ func listK8sEvents(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 	for pageLeft {
 		response, err = clientset.CoreV1().Events("").List(ctx, input)
 		if err != nil {
+plugin.Logger(ctx).Error("listK8sEvents", "api_err", err)
 			return nil, err
 		}
 

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -26,6 +26,27 @@ func tableKubernetesEvent(ctx context.Context) *plugin.Table {
 		},
 		Columns: k8sCommonColumns([]*plugin.Column{
 			{
+				Name:        "last_timestamp",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Description: "Time when this event was last observed.",
+				Transform:   transform.FromField("LastTimestamp").Transform(v1TimeToRFC3339),
+			},
+			{
+				Name:        "type",
+				Type:        proto.ColumnType_STRING,
+				Description: "Type of this event (Normal, Warning), new types could be added in the future.",
+			},
+			{
+				Name:        "reason",
+				Type:        proto.ColumnType_STRING,
+				Description: "The reason the transition into the object's current status.",
+			},
+			{
+				Name:        "message",
+				Type:        proto.ColumnType_STRING,
+				Description: "A description of the status of this operation.",
+			},
+			{
 				Name:        "action",
 				Type:        proto.ColumnType_STRING,
 				Description: "What action was taken/failed with the regarding object.",
@@ -48,33 +69,6 @@ func tableKubernetesEvent(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("FirstTimestamp").Transform(v1TimeToRFC3339),
 			},
 			{
-				Name:        "involved_object",
-				Type:        proto.ColumnType_JSON,
-				Description: "The object that this event is about.",
-				Transform:   transform.FromField("InvolvedObject"),
-			},
-			{
-				Name:        "last_timestamp",
-				Type:        proto.ColumnType_TIMESTAMP,
-				Description: "Time when this event was last observed.",
-				Transform:   transform.FromField("LastTimestamp").Transform(v1TimeToRFC3339),
-			},
-			{
-				Name:        "message",
-				Type:        proto.ColumnType_STRING,
-				Description: "A description of the status of this operation.",
-			},
-			{
-				Name:        "reason",
-				Type:        proto.ColumnType_STRING,
-				Description: "The reason the transition into the object's current status.",
-			},
-			{
-				Name:        "related",
-				Type:        proto.ColumnType_JSON,
-				Description: "Optional secondary object for more complex actions.",
-			},
-			{
 				Name:        "reporting_component",
 				Type:        proto.ColumnType_STRING,
 				Description: "Name of the controller that emitted this event.",
@@ -87,6 +81,17 @@ func tableKubernetesEvent(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("ReportingInstance"),
 			},
 			{
+				Name:        "involved_object",
+				Type:        proto.ColumnType_JSON,
+				Description: "The object that this event is about.",
+				Transform:   transform.FromField("InvolvedObject"),
+			},
+			{
+				Name:        "related",
+				Type:        proto.ColumnType_JSON,
+				Description: "Optional secondary object for more complex actions.",
+			},
+			{
 				Name:        "series",
 				Type:        proto.ColumnType_JSON,
 				Description: "Data about the event series this event represents.",
@@ -95,11 +100,6 @@ func tableKubernetesEvent(ctx context.Context) *plugin.Table {
 				Name:        "source",
 				Type:        proto.ColumnType_JSON,
 				Description: "The component reporting this event.",
-			},
-			{
-				Name:        "type",
-				Type:        proto.ColumnType_STRING,
-				Description: "Type of this event (Normal, Warning), new types could be added in the future.",
 			},
 		}),
 	}

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -180,6 +180,7 @@ func getK8sEvent(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 
 	clientset, err := GetNewClientset(ctx, d)
 	if err != nil {
+plugin.Logger(ctx).Error("getK8sEvent", "client_err", err)
 		return nil, err
 	}
 

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -175,7 +175,6 @@ func listK8sEvents(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 }
 
 func getK8sEvent(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	logger.Trace("getK8sEvent")
 
 	clientset, err := GetNewClientset(ctx, d)
 	if err != nil {

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -29,13 +29,11 @@ func tableKubernetesEvent(ctx context.Context) *plugin.Table {
 				Name:        "action",
 				Type:        proto.ColumnType_STRING,
 				Description: "What action was taken/failed with the regarding object.",
-				Transform:   transform.FromField("Action"),
 			},
 			{
 				Name:        "count",
 				Type:        proto.ColumnType_INT,
 				Description: "The number of times this event has occurred.",
-				Transform:   transform.FromField("Count"),
 			},
 			{
 				Name:        "event_time",
@@ -65,19 +63,16 @@ func tableKubernetesEvent(ctx context.Context) *plugin.Table {
 				Name:        "message",
 				Type:        proto.ColumnType_STRING,
 				Description: "A description of the status of this operation.",
-				Transform:   transform.FromField("Message"),
 			},
 			{
 				Name:        "reason",
 				Type:        proto.ColumnType_STRING,
 				Description: "The reason the transition into the object's current status.",
-				Transform:   transform.FromField("Reason"),
 			},
 			{
 				Name:        "related",
 				Type:        proto.ColumnType_JSON,
 				Description: "Optional secondary object for more complex actions.",
-				Transform:   transform.FromField("Related"),
 			},
 			{
 				Name:        "reporting_component",
@@ -95,19 +90,16 @@ func tableKubernetesEvent(ctx context.Context) *plugin.Table {
 				Name:        "series",
 				Type:        proto.ColumnType_JSON,
 				Description: "Data about the event series this event represents.",
-				Transform:   transform.FromField("Series"),
 			},
 			{
 				Name:        "source",
 				Type:        proto.ColumnType_JSON,
 				Description: "The component reporting this event.",
-				Transform:   transform.FromField("Source"),
 			},
 			{
 				Name:        "type",
 				Type:        proto.ColumnType_STRING,
 				Description: "Type of this event (Normal, Warning), new types could be added in the future.",
-				Transform:   transform.FromField("Type"),
 			},
 		}),
 	}

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -116,7 +116,6 @@ func tableKubernetesEvent(ctx context.Context) *plugin.Table {
 //// HYDRATE FUNCTIONS
 
 func listK8sEvents(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	logger.Trace("listK8sEvents")
 
 	clientset, err := GetNewClientset(ctx, d)
 	if err != nil {

--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -304,6 +304,24 @@ func v1TimeToRFC3339(_ context.Context, d *transform.TransformData) (interface{}
 	}
 }
 
+func v1MicroTimeToRFC3339(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	if d.Value == nil {
+		return nil, nil
+	}
+
+	switch v := d.Value.(type) {
+	case v1.MicroTime:
+		return v1.NewTime(v.Time).ToUnstructured(), nil
+	case *v1.MicroTime:
+		if v == nil {
+			return nil, nil
+		}
+		return v1.NewTime(v.Time).ToUnstructured(), nil
+	default:
+		return nil, fmt.Errorf("invalid time format %T! ", v)
+	}
+}
+
 func labelSelectorToString(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	if d.Value == nil {
 		return nil, nil


### PR DESCRIPTION
Add table for Kubernetes Events, which contain information about events occurring in the cluster.

# Example query results
<details>
  <summary>Results</summary>
  
```
$ steampipe query "select namespace, last_timestamp, type, reason, concat(involved_object ->> 'kind', '/', involved_object ->> 'name') as object, message from kubernetes_event limit 5;"
+-----------+---------------------------+--------+-------------------------+-------------------------+----------------------------------------------------------------+
| namespace | last_timestamp            | type   | reason                  | object                  | message                                                        |
+-----------+---------------------------+--------+-------------------------+-------------------------+----------------------------------------------------------------+
| default   | 2022-11-05T10:41:35-07:00 | Normal | Starting                | Node/kind-control-plane | Starting kubelet.                                              |
| default   | 2022-11-05T10:41:28-07:00 | Normal | NodeHasSufficientMemory | Node/kind-control-plane | Node kind-control-plane status is now: NodeHasSufficientMemory |
| default   | 2022-11-05T10:41:35-07:00 | Normal | NodeAllocatableEnforced | Node/kind-control-plane | Updated Node Allocatable limit across pods                     |
| default   | 2022-11-05T10:41:28-07:00 | Normal | NodeHasNoDiskPressure   | Node/kind-control-plane | Node kind-control-plane status is now: NodeHasNoDiskPressure   |
| default   | 2022-11-05T10:41:28-07:00 | Normal | NodeHasSufficientPID    | Node/kind-control-plane | Node kind-control-plane status is now: NodeHasSufficientPID    |
+-----------+---------------------------+--------+-------------------------+-------------------------+----------------------------------------------------------------+

```
</details>
