### PR TITLE
Add column title in kubernetes_config_map table closes #106

### DIFF
--- a/kubernetes/table_kubernetes_config_map.go
+++ b/kubernetes/table_kubernetes_config_map.go
@@ -43,12 +43,12 @@ func tableKubernetesConfigMap(ctx context.Context) *plugin.Table {
 			},
 
 			//// Steampipe Standard Columns
-			// {
-			// 	Name:        "title",
-			// 	Type:        proto.ColumnType_STRING,
-			// 	Description: ColumnDescriptionTitle,
-			// 	Transform:   transform.FromField("Name"),
-			// },
+			{
+				Name:        "title",
+				Type:        proto.ColumnType_STRING,
+				Description: ColumnDescriptionTitle,
+				Transform:   transform.FromField("Name"),
+			},
 			{
 				Name:        "tags",
 				Type:        proto.ColumnType_JSON,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/kubernetes_config_map []

PRETEST: tests/kubernetes_config_map
Running terraform

TEST: tests/kubernetes_config_map
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.create_config_map will be created
  + resource "null_resource" "create_config_map" {
      + id = (known after apply)
    }

  # null_resource.delay will be created
  + resource "null_resource" "delay" {
      + id = (known after apply)
    }

  # null_resource.get_config_map will be created
  + resource "null_resource" "get_config_map" {
      + id = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.
null_resource.delay: Creating...
null_resource.create_config_map: Creating...
null_resource.delay: Provisioning with 'local-exec'...
null_resource.delay (local-exec): Executing: ["/bin/sh" "-c" "sleep 45"]
null_resource.create_config_map: Provisioning with 'local-exec'...
null_resource.create_config_map (local-exec): Executing: ["/bin/sh" "-c" "kubectl apply -f /private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/kubernetes_config_map/terraform/test/config_map.yaml"]
null_resource.create_config_map (local-exec): configmap/game-demo created
null_resource.create_config_map: Creation complete after 1s [id=7659317285730141832]
null_resource.delay: Still creating... [10s elapsed]
null_resource.delay: Still creating... [20s elapsed]
null_resource.delay: Still creating... [30s elapsed]
null_resource.delay: Still creating... [40s elapsed]
null_resource.delay: Creation complete after 45s [id=3527927076098643099]
null_resource.get_config_map: Creating...
null_resource.get_config_map: Provisioning with 'local-exec'...
null_resource.get_config_map (local-exec): Executing: ["/bin/sh" "-c" "kubectl get configmaps"]
null_resource.get_config_map (local-exec): NAME               DATA   AGE
null_resource.get_config_map (local-exec): game-demo          4      45s
null_resource.get_config_map (local-exec): kube-root-ca.crt   1      315d
null_resource.get_config_map: Creation complete after 1s [id=6430489023531878056]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Running SQL query: test-get-query.sql

[
  {
    "key": "game.properties",
    "name": "game-demo",
    "namespace": "default",
    "value": "enemy.types=aliens,monsters\nplayer.maximum-lives=5\n"
  },
  {
    "key": "player_initial_lives",
    "name": "game-demo",
    "namespace": "default",
    "value": "3"
  },
  {
    "key": "ui_properties_file_name",
    "name": "game-demo",
    "namespace": "default",
    "value": "user-interface.properties"
  },
  {
    "key": "user-interface.properties",
    "name": "game-demo",
    "namespace": "default",
    "value": "color.good=purple\ncolor.bad=yellow\nallow.textmode=true\n"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "key": "game.properties",
    "name": "game-demo",
    "namespace": "default",
    "value": "enemy.types=aliens,monsters\nplayer.maximum-lives=5\n"
  },
  {
    "key": "player_initial_lives",
    "name": "game-demo",
    "namespace": "default",
    "value": "3"
  },
  {
    "key": "ui_properties_file_name",
    "name": "game-demo",
    "namespace": "default",
    "value": "user-interface.properties"
  },
  {
    "key": "user-interface.properties",
    "name": "game-demo",
    "namespace": "default",
    "value": "color.good=purple\ncolor.bad=yellow\nallow.textmode=true\n"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

POSTTEST: tests/kubernetes_config_map
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.delete_config_map will be created
  + resource "null_resource" "delete_config_map" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
null_resource.delete_config_map: Creating...
null_resource.delete_config_map: Provisioning with 'local-exec'...
null_resource.delete_config_map (local-exec): Executing: ["/bin/sh" "-c" "kubectl delete -f /private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/kubernetes_config_map/terraform/posttest/config_map.yaml"]
null_resource.delete_config_map (local-exec): configmap "game-demo" deleted
null_resource.delete_config_map: Creation complete after 0s [id=628149985965792980]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

TEARDOWN: tests/kubernetes_config_map



SUMMARY:

1/1 passed.
```
</details>


# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, title from kubernetes_config_map
+------------------------------------+------------------------------------+
| name                               | title                              |
+------------------------------------+------------------------------------+
| kube-root-ca.crt                   | kube-root-ca.crt                   |
| kubelet-config-1.23                | kubelet-config-1.23                |
| extension-apiserver-authentication | extension-apiserver-authentication |
| kube-root-ca.crt                   | kube-root-ca.crt                   |
| coredns                            | coredns                            |
| kubeadm-config                     | kubeadm-config                     |
| kube-root-ca.crt                   | kube-root-ca.crt                   |
| kube-proxy                         | kube-proxy                         |
| cluster-info                       | cluster-info                       |
| kube-root-ca.crt                   | kube-root-ca.crt                   |
+------------------------------------+------------------------------------+
```
</details>
