### PR TITLE
Fix error `Error: failed to populate column 'selector_query': rpc error: code = Internal desc = transform labelSelectorToString failed with panic interface conversion: interface {} is map[string]string, not *v1.LabelSelector (SQLSTATE HV000)`. Closes #125

### DIFF
--- a/kubernetes/table_kubernetes_replication_controller.go
+++ b/kubernetes/table_kubernetes_replication_controller.go
@@ -43,7 +43,7 @@ func tableKubernetesReplicaController(ctx context.Context) *plugin.Table {
 				Name:        "selector_query",
 				Type:        proto.ColumnType_STRING,
 				Description: "A query string representation of the selector.",
-				Transform:   transform.FromField("Spec.Selector").Transform(labelSelectorToString),
+				Transform:   transform.FromField("Spec.Selector").Transform(selectorMapToString),
 			},
 			{
 				Name:        "selector",


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
