### PR TITLE
fix: empty returned data field in configmap and secret tables

### DIFF
--- a/kubernetes/helm_template_render.go
+++ b/kubernetes/helm_template_render.go
@@ -221,7 +221,7 @@ func renderedHelmTemplateContentUncached(ctx context.Context, d *plugin.QueryDat
 			}
 
 			parsedContents = append(parsedContents, parsedContent{
-				Data:       targetObj,
+				ParsedData: targetObj,
 				Kind:       obj.GetKind(),
 				Path:       t.Path,
 				SourceType: fmt.Sprintf("helm_rendered:%s", t.ConfigKey),

--- a/kubernetes/plugin.go
+++ b/kubernetes/plugin.go
@@ -161,7 +161,7 @@ func listK8sDynamicCRDs(ctx context.Context, cn *connection.ConnectionCache, c *
 	// Also, skip the duplicate CRDs to avoid the conflicts.
 	for _, pattern := range filterCrds {
 		for _, item := range parsedContents {
-			crd := item.Data.(*v1.CustomResourceDefinition)
+			crd := item.ParsedData.(*v1.CustomResourceDefinition)
 
 			if helpers.StringSliceContains(temp_crd_names, crd.Name) {
 				continue

--- a/kubernetes/table_helm_template.go
+++ b/kubernetes/table_helm_template.go
@@ -20,7 +20,7 @@ func tableHelmTemplates(ctx context.Context) *plugin.Table {
 		Columns: []*plugin.Column{
 			{Name: "chart_name", Type: proto.ColumnType_STRING, Description: "The name of the chart."},
 			{Name: "path", Type: proto.ColumnType_STRING, Description: "The path to the template file."},
-			{Name: "raw", Type: proto.ColumnType_STRING, Description: "Data is the template as byte data."},
+			{Name: "raw", Type: proto.ColumnType_STRING, Description: "Raw is the template as byte data."},
 		},
 	}
 }

--- a/kubernetes/table_helm_template_rendered.go
+++ b/kubernetes/table_helm_template_rendered.go
@@ -21,7 +21,7 @@ func tableHelmTemplateRendered(ctx context.Context) *plugin.Table {
 			{Name: "path", Type: proto.ColumnType_STRING, Description: "The path to the template file."},
 			{Name: "chart_name", Type: proto.ColumnType_STRING, Description: "The name of the chart."},
 			{Name: "source_type", Type: proto.ColumnType_STRING, Description: "The source of the template."},
-			{Name: "rendered", Type: proto.ColumnType_STRING, Description: "Data is the template as byte data."},
+			{Name: "rendered", Type: proto.ColumnType_STRING, Description: "Rendered is the rendered template as byte data."},
 		},
 	}
 }

--- a/kubernetes/table_kubernetes_cluster_role.go
+++ b/kubernetes/table_kubernetes_cluster_role.go
@@ -88,7 +88,7 @@ func listK8sClusterRoles(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	for _, content := range parsedContents {
-		clusterRole := content.Data.(*v1.ClusterRole)
+		clusterRole := content.ParsedData.(*v1.ClusterRole)
 
 		d.StreamListItem(ctx, ClusterRole{*clusterRole, content})
 
@@ -171,7 +171,7 @@ func getK8sClusterRole(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 	}
 
 	for _, content := range parsedContents {
-		clusterRole := content.Data.(*v1.ClusterRole)
+		clusterRole := content.ParsedData.(*v1.ClusterRole)
 
 		if clusterRole.Name == name {
 			return ClusterRole{*clusterRole, content}, nil

--- a/kubernetes/table_kubernetes_cluster_role_binding.go
+++ b/kubernetes/table_kubernetes_cluster_role_binding.go
@@ -102,7 +102,7 @@ func listK8sClusterRoleBindings(ctx context.Context, d *plugin.QueryData, _ *plu
 	}
 
 	for _, content := range parsedContents {
-		clusterRoleBinding := content.Data.(*v1.ClusterRoleBinding)
+		clusterRoleBinding := content.ParsedData.(*v1.ClusterRoleBinding)
 
 		d.StreamListItem(ctx, ClusterRoleBinding{*clusterRoleBinding, content})
 
@@ -186,7 +186,7 @@ func getK8sClusterRoleBinding(ctx context.Context, d *plugin.QueryData, _ *plugi
 	}
 
 	for _, content := range parsedContents {
-		clusterRoleBinding := content.Data.(*v1.ClusterRoleBinding)
+		clusterRoleBinding := content.ParsedData.(*v1.ClusterRoleBinding)
 
 		if clusterRoleBinding.Name == name {
 			return ClusterRoleBinding{*clusterRoleBinding, content}, nil

--- a/kubernetes/table_kubernetes_config_map.go
+++ b/kubernetes/table_kubernetes_config_map.go
@@ -95,7 +95,7 @@ func listK8sConfigMaps(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 	}
 
 	for _, content := range parsedContents {
-		configMap := content.Data.(*v1.ConfigMap)
+		configMap := content.ParsedData.(*v1.ConfigMap)
 
 		d.StreamListItem(ctx, ConfigMap{*configMap, content})
 
@@ -186,7 +186,7 @@ func getK8sConfigMap(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	}
 
 	for _, content := range parsedContents {
-		configMap := content.Data.(*v1.ConfigMap)
+		configMap := content.ParsedData.(*v1.ConfigMap)
 
 		if configMap.Name == name && configMap.Namespace == namespace {
 			return ConfigMap{*configMap, content}, nil

--- a/kubernetes/table_kubernetes_cronjob.go
+++ b/kubernetes/table_kubernetes_cronjob.go
@@ -142,7 +142,7 @@ func listK8sCronJobs(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	}
 
 	for _, content := range parsedContents {
-		cronJob := content.Data.(*v1.CronJob)
+		cronJob := content.ParsedData.(*v1.CronJob)
 
 		d.StreamListItem(ctx, CronJob{*cronJob, content})
 
@@ -233,7 +233,7 @@ func getK8sCronJob(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 	}
 
 	for _, content := range parsedContents {
-		cronJob := content.Data.(*v1.CronJob)
+		cronJob := content.ParsedData.(*v1.CronJob)
 
 		if cronJob.Name == name && cronJob.Namespace == namespace {
 			return CronJob{*cronJob, content}, nil

--- a/kubernetes/table_kubernetes_custom_resource.go
+++ b/kubernetes/table_kubernetes_custom_resource.go
@@ -147,7 +147,7 @@ func listK8sCustomResources(ctx context.Context, crdName string, resourceName st
 		}
 
 		for _, content := range parsedContents {
-			deployment := content.Data.(*unstructured.Unstructured)
+			deployment := content.ParsedData.(*unstructured.Unstructured)
 
 			// Also, the apiVersion of the custom resource must be in format of <groupName in CRD>/<spec version in CRD>
 			if !(deployment.GetAPIVersion() == fmt.Sprintf("%s/%s", groupName, activeVersion)) {

--- a/kubernetes/table_kubernetes_custom_resource_definition.go
+++ b/kubernetes/table_kubernetes_custom_resource_definition.go
@@ -69,7 +69,7 @@ func listK8sCustomResourceDefinitions(ctx context.Context, d *plugin.QueryData, 
 	}
 
 	for _, content := range parsedContents {
-		crd := content.Data.(*v1.CustomResourceDefinition)
+		crd := content.ParsedData.(*v1.CustomResourceDefinition)
 
 		d.StreamListItem(ctx, CustomResourceDefinition{*crd, content})
 
@@ -148,7 +148,7 @@ func getK8sCustomResourceDefinition(ctx context.Context, d *plugin.QueryData, _ 
 	}
 
 	for _, content := range parsedContents {
-		crd := content.Data.(*v1.CustomResourceDefinition)
+		crd := content.ParsedData.(*v1.CustomResourceDefinition)
 
 		if crd.Name == name {
 			return CustomResourceDefinition{*crd, content}, nil

--- a/kubernetes/table_kubernetes_daemonset.go
+++ b/kubernetes/table_kubernetes_daemonset.go
@@ -179,7 +179,7 @@ func listK8sDaemonSets(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 	}
 
 	for _, content := range parsedContents {
-		daemonSet := content.Data.(*v1.DaemonSet)
+		daemonSet := content.ParsedData.(*v1.DaemonSet)
 
 		d.StreamListItem(ctx, DaemonSet{*daemonSet, content})
 
@@ -270,7 +270,7 @@ func getK8sDaemonSet(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	}
 
 	for _, content := range parsedContents {
-		daemonSet := content.Data.(*v1.DaemonSet)
+		daemonSet := content.ParsedData.(*v1.DaemonSet)
 
 		if daemonSet.Name == name && daemonSet.Namespace == namespace {
 			return DaemonSet{*daemonSet, content}, nil

--- a/kubernetes/table_kubernetes_deployment.go
+++ b/kubernetes/table_kubernetes_deployment.go
@@ -185,7 +185,7 @@ func listK8sDeployments(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	}
 
 	for _, content := range parsedContents {
-		deployment := content.Data.(*v1.Deployment)
+		deployment := content.ParsedData.(*v1.Deployment)
 
 		d.StreamListItem(ctx, Deployment{*deployment, content})
 
@@ -277,7 +277,7 @@ func getK8sDeployment(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 	}
 
 	for _, content := range parsedContents {
-		deployment := content.Data.(*v1.Deployment)
+		deployment := content.ParsedData.(*v1.Deployment)
 
 		if deployment.Name == name && deployment.Namespace == namespace {
 			return Deployment{*deployment, content}, nil

--- a/kubernetes/table_kubernetes_endpoint_slice.go
+++ b/kubernetes/table_kubernetes_endpoint_slice.go
@@ -94,7 +94,7 @@ func listK8sEnpointSlices(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 	}
 
 	for _, content := range parsedContents {
-		endpointSlice := content.Data.(*v1.EndpointSlice)
+		endpointSlice := content.ParsedData.(*v1.EndpointSlice)
 
 		d.StreamListItem(ctx, EndpointSlice{*endpointSlice, content})
 
@@ -185,7 +185,7 @@ func getK8sEnpointSlice(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	}
 
 	for _, content := range parsedContents {
-		endpointSlice := content.Data.(*v1.EndpointSlice)
+		endpointSlice := content.ParsedData.(*v1.EndpointSlice)
 
 		if endpointSlice.Name == name && endpointSlice.Namespace == namespace {
 			return EndpointSlice{*endpointSlice, content}, nil

--- a/kubernetes/table_kubernetes_endpoints.go
+++ b/kubernetes/table_kubernetes_endpoints.go
@@ -84,7 +84,7 @@ func listK8sEnpoints(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	}
 
 	for _, content := range parsedContents {
-		endpoints := content.Data.(*v1.Endpoints)
+		endpoints := content.ParsedData.(*v1.Endpoints)
 
 		d.StreamListItem(ctx, Endpoints{*endpoints, content})
 
@@ -175,7 +175,7 @@ func getK8sEndpoint(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	}
 
 	for _, content := range parsedContents {
-		endpoints := content.Data.(*v1.Endpoints)
+		endpoints := content.ParsedData.(*v1.Endpoints)
 
 		if endpoints.Name == name && endpoints.Namespace == namespace {
 			return Endpoints{*endpoints, content}, nil

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -140,7 +140,7 @@ func listK8sEvents(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 	}
 
 	for _, content := range parsedContents {
-		event := content.Data.(*v1.Event)
+		event := content.ParsedData.(*v1.Event)
 
 		d.StreamListItem(ctx, Event{*event, content})
 
@@ -231,7 +231,7 @@ func getK8sEvent(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	}
 
 	for _, content := range parsedContents {
-		event := content.Data.(*v1.Event)
+		event := content.ParsedData.(*v1.Event)
 
 		if event.Name == name && event.Namespace == namespace {
 			return Event{*event, content}, nil

--- a/kubernetes/table_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/table_kubernetes_horizontal_pod_autoscaler.go
@@ -152,7 +152,7 @@ func listK8sHPAs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	}
 
 	for _, content := range parsedContents {
-		hpa := content.Data.(*v1.HorizontalPodAutoscaler)
+		hpa := content.ParsedData.(*v1.HorizontalPodAutoscaler)
 
 		d.StreamListItem(ctx, HorizontalPodAutoscaler{*hpa, content})
 
@@ -242,7 +242,7 @@ func getK8sHPA(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 	}
 
 	for _, content := range parsedContents {
-		hpa := content.Data.(*v1.HorizontalPodAutoscaler)
+		hpa := content.ParsedData.(*v1.HorizontalPodAutoscaler)
 
 		if hpa.Name == name && hpa.Namespace == namespace {
 			return HorizontalPodAutoscaler{*hpa, content}, nil

--- a/kubernetes/table_kubernetes_ingress.go
+++ b/kubernetes/table_kubernetes_ingress.go
@@ -112,7 +112,7 @@ func listK8sIngresses(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 	}
 
 	for _, content := range parsedContents {
-		ingress := content.Data.(*v1.Ingress)
+		ingress := content.ParsedData.(*v1.Ingress)
 
 		d.StreamListItem(ctx, Ingress{*ingress, content})
 
@@ -203,7 +203,7 @@ func getK8sIngress(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 	}
 
 	for _, content := range parsedContents {
-		ingress := content.Data.(*v1.Ingress)
+		ingress := content.ParsedData.(*v1.Ingress)
 
 		if ingress.Name == name && ingress.Namespace == namespace {
 			return Ingress{*ingress, content}, nil

--- a/kubernetes/table_kubernetes_job.go
+++ b/kubernetes/table_kubernetes_job.go
@@ -172,7 +172,7 @@ func listK8sJobs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	}
 
 	for _, content := range parsedContents {
-		job := content.Data.(*v1.Job)
+		job := content.ParsedData.(*v1.Job)
 
 		d.StreamListItem(ctx, Job{*job, content})
 
@@ -263,7 +263,7 @@ func getK8sJob(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 	}
 
 	for _, content := range parsedContents {
-		job := content.Data.(*v1.Job)
+		job := content.ParsedData.(*v1.Job)
 
 		if job.Name == name && job.Namespace == namespace {
 			return Job{*job, content}, nil

--- a/kubernetes/table_kubernetes_limit_range.go
+++ b/kubernetes/table_kubernetes_limit_range.go
@@ -86,7 +86,7 @@ func listK8sLimitRanges(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	}
 
 	for _, content := range parsedContents {
-		limitRange := content.Data.(*v1.LimitRange)
+		limitRange := content.ParsedData.(*v1.LimitRange)
 
 		d.StreamListItem(ctx, LimitRange{*limitRange, content})
 
@@ -176,7 +176,7 @@ func getK8sLimitRange(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 	}
 
 	for _, content := range parsedContents {
-		limitRange := content.Data.(*v1.LimitRange)
+		limitRange := content.ParsedData.(*v1.LimitRange)
 
 		if limitRange.Name == name && limitRange.Namespace == namespace {
 			return LimitRange{*limitRange, content}, nil

--- a/kubernetes/table_kubernetes_namespace.go
+++ b/kubernetes/table_kubernetes_namespace.go
@@ -103,7 +103,7 @@ func listK8sNamespaces(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 	}
 
 	for _, content := range parsedContents {
-		namespace := content.Data.(*v1.Namespace)
+		namespace := content.ParsedData.(*v1.Namespace)
 
 		d.StreamListItem(ctx, Namespace{*namespace, content})
 
@@ -191,7 +191,7 @@ func getK8sNamespace(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	}
 
 	for _, content := range parsedContents {
-		namespace := content.Data.(*v1.Namespace)
+		namespace := content.ParsedData.(*v1.Namespace)
 
 		if namespace.Name == name {
 			return Namespace{*namespace, content}, nil

--- a/kubernetes/table_kubernetes_network_policy.go
+++ b/kubernetes/table_kubernetes_network_policy.go
@@ -104,7 +104,7 @@ func listK8sNetworkPolicies(ctx context.Context, d *plugin.QueryData, _ *plugin.
 	}
 
 	for _, content := range parsedContents {
-		networkPolicy := content.Data.(*v1.NetworkPolicy)
+		networkPolicy := content.ParsedData.(*v1.NetworkPolicy)
 
 		d.StreamListItem(ctx, NetworkPolicy{*networkPolicy, content})
 
@@ -195,7 +195,7 @@ func getK8sNetworkPolicy(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	for _, content := range parsedContents {
-		networkPolicy := content.Data.(*v1.NetworkPolicy)
+		networkPolicy := content.ParsedData.(*v1.NetworkPolicy)
 
 		if networkPolicy.Name == name && networkPolicy.Namespace == namespace {
 			return NetworkPolicy{*networkPolicy, content}, nil

--- a/kubernetes/table_kubernetes_node.go
+++ b/kubernetes/table_kubernetes_node.go
@@ -183,7 +183,7 @@ func listK8sNodes(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 	}
 
 	for _, content := range parsedContents {
-		node := content.Data.(*v1.Node)
+		node := content.ParsedData.(*v1.Node)
 
 		d.StreamListItem(ctx, Node{*node, content})
 
@@ -267,7 +267,7 @@ func getK8sNode(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 	}
 
 	for _, content := range parsedContents {
-		node := content.Data.(*v1.Node)
+		node := content.ParsedData.(*v1.Node)
 
 		if node.Name == name {
 			return Node{*node, content}, nil

--- a/kubernetes/table_kubernetes_persistent_volume.go
+++ b/kubernetes/table_kubernetes_persistent_volume.go
@@ -152,7 +152,7 @@ func listK8sPVs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 	}
 
 	for _, content := range parsedContents {
-		persistentVolume := content.Data.(*v1.PersistentVolume)
+		persistentVolume := content.ParsedData.(*v1.PersistentVolume)
 
 		d.StreamListItem(ctx, PersistentVolume{*persistentVolume, content})
 
@@ -236,7 +236,7 @@ func getK8sPV(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (
 	}
 
 	for _, content := range parsedContents {
-		persistentVolume := content.Data.(*v1.PersistentVolume)
+		persistentVolume := content.ParsedData.(*v1.PersistentVolume)
 
 		if persistentVolume.Name == name {
 			return PersistentVolume{*persistentVolume, content}, nil

--- a/kubernetes/table_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/table_kubernetes_persistent_volume_claim.go
@@ -148,7 +148,7 @@ func listK8sPVCs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	}
 
 	for _, content := range parsedContents {
-		persistentVolumeClaim := content.Data.(*v1.PersistentVolumeClaim)
+		persistentVolumeClaim := content.ParsedData.(*v1.PersistentVolumeClaim)
 
 		d.StreamListItem(ctx, PersistentVolumeClaim{*persistentVolumeClaim, content})
 
@@ -239,7 +239,7 @@ func getK8sPVC(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 	}
 
 	for _, content := range parsedContents {
-		persistentVolumeClaim := content.Data.(*v1.PersistentVolumeClaim)
+		persistentVolumeClaim := content.ParsedData.(*v1.PersistentVolumeClaim)
 
 		if persistentVolumeClaim.Name == name && persistentVolumeClaim.Namespace == namespace {
 			return PersistentVolumeClaim{*persistentVolumeClaim, content}, nil

--- a/kubernetes/table_kubernetes_pod.go
+++ b/kubernetes/table_kubernetes_pod.go
@@ -455,7 +455,7 @@ func listK8sPods(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	}
 
 	for _, content := range parsedContents {
-		pod := content.Data.(*v1.Pod)
+		pod := content.ParsedData.(*v1.Pod)
 
 		d.StreamListItem(ctx, Pod{*pod, content})
 
@@ -552,7 +552,7 @@ func getK8sPod(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 	}
 
 	for _, content := range parsedContents {
-		pod := content.Data.(*v1.Pod)
+		pod := content.ParsedData.(*v1.Pod)
 
 		if pod.Name == name && pod.Namespace == namespace {
 			return Pod{*pod, content}, nil

--- a/kubernetes/table_kubernetes_pod_disruption_budget.go
+++ b/kubernetes/table_kubernetes_pod_disruption_budget.go
@@ -100,7 +100,7 @@ func listPDBs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (
 	}
 
 	for _, content := range parsedContents {
-		pdb := content.Data.(*v1.PodDisruptionBudget)
+		pdb := content.ParsedData.(*v1.PodDisruptionBudget)
 
 		d.StreamListItem(ctx, PodDisruptionBudget{*pdb, content})
 
@@ -191,7 +191,7 @@ func getPDB(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (in
 	}
 
 	for _, content := range parsedContents {
-		pdb := content.Data.(*v1.PodDisruptionBudget)
+		pdb := content.ParsedData.(*v1.PodDisruptionBudget)
 
 		if pdb.Name == name && pdb.Namespace == namespace {
 			return PodDisruptionBudget{*pdb, content}, nil

--- a/kubernetes/table_kubernetes_pod_security_policy.go
+++ b/kubernetes/table_kubernetes_pod_security_policy.go
@@ -222,7 +222,7 @@ func listPodSecurityPolicy(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	}
 
 	for _, content := range parsedContents {
-		podSecurityPolicy := content.Data.(*v1beta1.PodSecurityPolicy)
+		podSecurityPolicy := content.ParsedData.(*v1beta1.PodSecurityPolicy)
 
 		d.StreamListItem(ctx, PodSecurityPolicy{*podSecurityPolicy, content})
 
@@ -306,7 +306,7 @@ func getPodSecurityPolicy(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 	}
 
 	for _, content := range parsedContents {
-		podSecurityPolicy := content.Data.(*v1beta1.PodSecurityPolicy)
+		podSecurityPolicy := content.ParsedData.(*v1beta1.PodSecurityPolicy)
 
 		if podSecurityPolicy.Name == name {
 			return PodSecurityPolicy{*podSecurityPolicy, content}, nil

--- a/kubernetes/table_kubernetes_replicaset.go
+++ b/kubernetes/table_kubernetes_replicaset.go
@@ -149,7 +149,7 @@ func listK8sReplicaSets(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	}
 
 	for _, content := range parsedContents {
-		replicaSet := content.Data.(*v1.ReplicaSet)
+		replicaSet := content.ParsedData.(*v1.ReplicaSet)
 
 		d.StreamListItem(ctx, ReplicaSet{*replicaSet, content})
 
@@ -240,7 +240,7 @@ func getK8sReplicaSet(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 	}
 
 	for _, content := range parsedContents {
-		replicaSet := content.Data.(*v1.ReplicaSet)
+		replicaSet := content.ParsedData.(*v1.ReplicaSet)
 
 		if replicaSet.Name == name && replicaSet.Namespace == namespace {
 			return ReplicaSet{*replicaSet, content}, nil

--- a/kubernetes/table_kubernetes_replication_controller.go
+++ b/kubernetes/table_kubernetes_replication_controller.go
@@ -149,7 +149,7 @@ func listK8sReplicaControllers(ctx context.Context, d *plugin.QueryData, _ *plug
 	}
 
 	for _, content := range parsedContents {
-		replicationController := content.Data.(*v1.ReplicationController)
+		replicationController := content.ParsedData.(*v1.ReplicationController)
 
 		d.StreamListItem(ctx, ReplicationController{*replicationController, content})
 
@@ -240,7 +240,7 @@ func getK8sReplicaController(ctx context.Context, d *plugin.QueryData, _ *plugin
 	}
 
 	for _, content := range parsedContents {
-		replicationController := content.Data.(*v1.ReplicationController)
+		replicationController := content.ParsedData.(*v1.ReplicationController)
 
 		if replicationController.Name == name && replicationController.Namespace == namespace {
 			return ReplicationController{*replicationController, content}, nil

--- a/kubernetes/table_kubernetes_resource_quota.go
+++ b/kubernetes/table_kubernetes_resource_quota.go
@@ -112,7 +112,7 @@ func listK8sResourceQuotas(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	}
 
 	for _, content := range parsedContents {
-		resourceQuota := content.Data.(*v1.ResourceQuota)
+		resourceQuota := content.ParsedData.(*v1.ResourceQuota)
 
 		d.StreamListItem(ctx, ResourceQuota{*resourceQuota, content})
 
@@ -202,7 +202,7 @@ func getK8sResourceQuota(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	for _, content := range parsedContents {
-		resourceQuota := content.Data.(*v1.ResourceQuota)
+		resourceQuota := content.ParsedData.(*v1.ResourceQuota)
 
 		if resourceQuota.Name == name && resourceQuota.Namespace == namespace {
 			return ResourceQuota{*resourceQuota, content}, nil

--- a/kubernetes/table_kubernetes_role.go
+++ b/kubernetes/table_kubernetes_role.go
@@ -84,7 +84,7 @@ func listK8sRoles(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 	}
 
 	for _, content := range parsedContents {
-		role := content.Data.(*v1.Role)
+		role := content.ParsedData.(*v1.Role)
 
 		d.StreamListItem(ctx, Role{*role, content})
 
@@ -175,7 +175,7 @@ func getK8sRole(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 	}
 
 	for _, content := range parsedContents {
-		role := content.Data.(*v1.Role)
+		role := content.ParsedData.(*v1.Role)
 
 		if role.Name == name && role.Namespace == namespace {
 			return Role{*role, content}, nil

--- a/kubernetes/table_kubernetes_role_binding.go
+++ b/kubernetes/table_kubernetes_role_binding.go
@@ -104,7 +104,7 @@ func listK8sRoleBindings(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	for _, content := range parsedContents {
-		roleBinding := content.Data.(*v1.RoleBinding)
+		roleBinding := content.ParsedData.(*v1.RoleBinding)
 
 		d.StreamListItem(ctx, RoleBinding{*roleBinding, content})
 
@@ -195,7 +195,7 @@ func getK8sRoleBinding(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 	}
 
 	for _, content := range parsedContents {
-		roleBinding := content.Data.(*v1.RoleBinding)
+		roleBinding := content.ParsedData.(*v1.RoleBinding)
 
 		if roleBinding.Name == name && roleBinding.Namespace == namespace {
 			return RoleBinding{*roleBinding, content}, nil

--- a/kubernetes/table_kubernetes_secret.go
+++ b/kubernetes/table_kubernetes_secret.go
@@ -103,7 +103,7 @@ func listK8sSecrets(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	}
 
 	for _, content := range parsedContents {
-		secret := content.Data.(*v1.Secret)
+		secret := content.ParsedData.(*v1.Secret)
 
 		d.StreamListItem(ctx, Secret{*secret, content})
 
@@ -198,7 +198,7 @@ func getK8sSecret(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 	}
 
 	for _, content := range parsedContents {
-		secret := content.Data.(*v1.Secret)
+		secret := content.ParsedData.(*v1.Secret)
 
 		if secret.Name == name && secret.Namespace == namespace {
 			return Secret{*secret, content}, nil

--- a/kubernetes/table_kubernetes_service.go
+++ b/kubernetes/table_kubernetes_service.go
@@ -200,7 +200,7 @@ func listK8sServices(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	}
 
 	for _, content := range parsedContents {
-		service := content.Data.(*v1.Service)
+		service := content.ParsedData.(*v1.Service)
 
 		d.StreamListItem(ctx, Service{*service, content})
 
@@ -290,7 +290,7 @@ func getK8sService(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 	}
 
 	for _, content := range parsedContents {
-		service := content.Data.(*v1.Service)
+		service := content.ParsedData.(*v1.Service)
 
 		if service.Name == name && service.Namespace == namespace {
 			return Service{*service, content}, nil

--- a/kubernetes/table_kubernetes_service_account.go
+++ b/kubernetes/table_kubernetes_service_account.go
@@ -95,7 +95,7 @@ func listK8sServiceAccounts(ctx context.Context, d *plugin.QueryData, _ *plugin.
 	}
 
 	for _, content := range parsedContents {
-		serviceAccount := content.Data.(*v1.ServiceAccount)
+		serviceAccount := content.ParsedData.(*v1.ServiceAccount)
 
 		d.StreamListItem(ctx, ServiceAccount{*serviceAccount, content})
 
@@ -186,7 +186,7 @@ func getK8sServiceAccount(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 	}
 
 	for _, content := range parsedContents {
-		serviceAccount := content.Data.(*v1.ServiceAccount)
+		serviceAccount := content.ParsedData.(*v1.ServiceAccount)
 
 		if serviceAccount.Name == name && serviceAccount.Namespace == namespace {
 			return ServiceAccount{*serviceAccount, content}, nil

--- a/kubernetes/table_kubernetes_stateful_set.go
+++ b/kubernetes/table_kubernetes_stateful_set.go
@@ -170,7 +170,7 @@ func listK8sStatefulSets(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	for _, content := range parsedContents {
-		statefulSet := content.Data.(*v1.StatefulSet)
+		statefulSet := content.ParsedData.(*v1.StatefulSet)
 
 		d.StreamListItem(ctx, StatefulSet{*statefulSet, content})
 
@@ -261,7 +261,7 @@ func getK8sStatefulSet(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 	}
 
 	for _, content := range parsedContents {
-		statefulSet := content.Data.(*v1.StatefulSet)
+		statefulSet := content.ParsedData.(*v1.StatefulSet)
 
 		if statefulSet.Name == name && statefulSet.Namespace == namespace {
 			return StatefulSet{*statefulSet, content}, nil

--- a/kubernetes/table_kubernetes_storage_class.go
+++ b/kubernetes/table_kubernetes_storage_class.go
@@ -107,7 +107,7 @@ func listK8sStorageClasses(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	}
 
 	for _, content := range parsedContents {
-		storageClass := content.Data.(*v1.StorageClass)
+		storageClass := content.ParsedData.(*v1.StorageClass)
 
 		d.StreamListItem(ctx, StorageClass{*storageClass, content})
 
@@ -192,7 +192,7 @@ func getK8sStorageClass(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	}
 
 	for _, content := range parsedContents {
-		storageClass := content.Data.(*v1.StorageClass)
+		storageClass := content.ParsedData.(*v1.StorageClass)
 
 		if storageClass.Name == name {
 			return StorageClass{*storageClass, content}, nil

--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -654,7 +654,7 @@ func mergeTags(labels map[string]string, annotations map[string]string) map[stri
 //// Utility functions for manifest files
 
 type parsedContent struct {
-	Data       any
+	ParsedData any
 	Kind       string
 	Path       string
 	SourceType string
@@ -774,7 +774,7 @@ func parsedManifestFileContentUncached(ctx context.Context, d *plugin.QueryData,
 			}
 
 			parsedContents = append(parsedContents, parsedContent{
-				Data:       targetObj,
+				ParsedData: targetObj,
 				Kind:       obj.GetKind(),
 				Path:       path,
 				SourceType: "manifest",


### PR DESCRIPTION
see details in #149 

this PR proposes to rename the Data field in the parsedContent struct from Data to ParsedData,
in order to avoid collisions with the Data field from other structs parsedContent is being merged in.

---

note: it was not clear to me where I could add something to allow for automated tests to ensure no regressions in the future (for example with other possible fields 🤔 )

note: tested locally through the `make install` to validate I was able to retrieve configmap data once more 🙂 