### PR TITLE
fix: pass namespace qualifier to Kubernetes API

### DIFF
--- a/kubernetes/table_kubernetes_config_map.go
+++ b/kubernetes/table_kubernetes_config_map.go
@@ -136,7 +136,7 @@ func listK8sConfigMaps(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.CoreV1().ConfigMaps("").List(ctx, input)
+		response, err = clientset.CoreV1().ConfigMaps(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_cronjob.go
+++ b/kubernetes/table_kubernetes_cronjob.go
@@ -182,7 +182,7 @@ func listK8sCronJobs(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	var response *v1.CronJobList
 	pageLeft := true
 	for pageLeft {
-		response, err = clientset.BatchV1().CronJobs("").List(ctx, input)
+		response, err = clientset.BatchV1().CronJobs(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			logger.Error("listK8sCronJobs", "list_err", err)
 			return nil, err

--- a/kubernetes/table_kubernetes_daemonset.go
+++ b/kubernetes/table_kubernetes_daemonset.go
@@ -220,7 +220,7 @@ func listK8sDaemonSets(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.AppsV1().DaemonSets("").List(ctx, input)
+		response, err = clientset.AppsV1().DaemonSets(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_deployment.go
+++ b/kubernetes/table_kubernetes_deployment.go
@@ -227,7 +227,7 @@ func listK8sDeployments(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 
 	for pageLeft {
 
-		response, err = clientset.AppsV1().Deployments("").List(ctx, input)
+		response, err = clientset.AppsV1().Deployments(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_endpoint_slice.go
+++ b/kubernetes/table_kubernetes_endpoint_slice.go
@@ -135,7 +135,7 @@ func listK8sEnpointSlices(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.DiscoveryV1().EndpointSlices("").List(ctx, input)
+		response, err = clientset.DiscoveryV1().EndpointSlices(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_endpoints.go
+++ b/kubernetes/table_kubernetes_endpoints.go
@@ -125,7 +125,7 @@ func listK8sEnpoints(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.CoreV1().Endpoints("").List(ctx, input)
+		response, err = clientset.CoreV1().Endpoints(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_event.go
+++ b/kubernetes/table_kubernetes_event.go
@@ -181,7 +181,7 @@ func listK8sEvents(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.CoreV1().Events("").List(ctx, input)
+		response, err = clientset.CoreV1().Events(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			plugin.Logger(ctx).Error("listK8sEvents", "api_err", err)
 			return nil, err

--- a/kubernetes/table_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/table_kubernetes_horizontal_pod_autoscaler.go
@@ -193,7 +193,7 @@ func listK8sHPAs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.AutoscalingV1().HorizontalPodAutoscalers("").List(ctx, input)
+		response, err = clientset.AutoscalingV1().HorizontalPodAutoscalers(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			plugin.Logger(ctx).Error("listK8sHPAs", "api_err", err)
 			return nil, err

--- a/kubernetes/table_kubernetes_ingress.go
+++ b/kubernetes/table_kubernetes_ingress.go
@@ -153,7 +153,7 @@ func listK8sIngresses(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.NetworkingV1().Ingresses("").List(ctx, input)
+		response, err = clientset.NetworkingV1().Ingresses(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_job.go
+++ b/kubernetes/table_kubernetes_job.go
@@ -213,7 +213,7 @@ func listK8sJobs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.BatchV1().Jobs("").List(ctx, input)
+		response, err = clientset.BatchV1().Jobs(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_limit_range.go
+++ b/kubernetes/table_kubernetes_limit_range.go
@@ -127,7 +127,7 @@ func listK8sLimitRanges(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.CoreV1().LimitRanges("").List(ctx, input)
+		response, err = clientset.CoreV1().LimitRanges(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_network_policy.go
+++ b/kubernetes/table_kubernetes_network_policy.go
@@ -145,7 +145,7 @@ func listK8sNetworkPolicies(ctx context.Context, d *plugin.QueryData, _ *plugin.
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.NetworkingV1().NetworkPolicies("").List(ctx, input)
+		response, err = clientset.NetworkingV1().NetworkPolicies(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/table_kubernetes_persistent_volume_claim.go
@@ -189,7 +189,7 @@ func listK8sPVCs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.CoreV1().PersistentVolumeClaims("").List(ctx, input)
+		response, err = clientset.CoreV1().PersistentVolumeClaims(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_pod.go
+++ b/kubernetes/table_kubernetes_pod.go
@@ -502,7 +502,7 @@ func listK8sPods(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.CoreV1().Pods("").List(ctx, input)
+		response, err = clientset.CoreV1().Pods(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_pod_disruption_budget.go
+++ b/kubernetes/table_kubernetes_pod_disruption_budget.go
@@ -141,7 +141,7 @@ func listPDBs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.PolicyV1().PodDisruptionBudgets("").List(ctx, input)
+		response, err = clientset.PolicyV1().PodDisruptionBudgets(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_pod_template.go
+++ b/kubernetes/table_kubernetes_pod_template.go
@@ -125,7 +125,7 @@ func listK8sPodTemplates(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.CoreV1().PodTemplates("").List(ctx, input)
+		response, err = clientset.CoreV1().PodTemplates(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_replicaset.go
+++ b/kubernetes/table_kubernetes_replicaset.go
@@ -190,7 +190,7 @@ func listK8sReplicaSets(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.AppsV1().ReplicaSets("").List(ctx, input)
+		response, err = clientset.AppsV1().ReplicaSets(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_replication_controller.go
+++ b/kubernetes/table_kubernetes_replication_controller.go
@@ -190,7 +190,7 @@ func listK8sReplicaControllers(ctx context.Context, d *plugin.QueryData, _ *plug
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.CoreV1().ReplicationControllers("").List(ctx, input)
+		response, err = clientset.CoreV1().ReplicationControllers(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_resource_quota.go
+++ b/kubernetes/table_kubernetes_resource_quota.go
@@ -153,7 +153,7 @@ func listK8sResourceQuotas(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.CoreV1().ResourceQuotas("").List(ctx, input)
+		response, err = clientset.CoreV1().ResourceQuotas(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_role.go
+++ b/kubernetes/table_kubernetes_role.go
@@ -125,7 +125,7 @@ func listK8sRoles(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.RbacV1().Roles("").List(ctx, input)
+		response, err = clientset.RbacV1().Roles(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_role_binding.go
+++ b/kubernetes/table_kubernetes_role_binding.go
@@ -145,7 +145,7 @@ func listK8sRoleBindings(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.RbacV1().RoleBindings("").List(ctx, input)
+		response, err = clientset.RbacV1().RoleBindings(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_secret.go
+++ b/kubernetes/table_kubernetes_secret.go
@@ -148,7 +148,7 @@ func listK8sSecrets(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.CoreV1().Secrets("").List(ctx, input)
+		response, err = clientset.CoreV1().Secrets(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_service.go
+++ b/kubernetes/table_kubernetes_service.go
@@ -241,7 +241,7 @@ func listK8sServices(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.CoreV1().Services("").List(ctx, input)
+		response, err = clientset.CoreV1().Services(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_service_account.go
+++ b/kubernetes/table_kubernetes_service_account.go
@@ -136,7 +136,7 @@ func listK8sServiceAccounts(ctx context.Context, d *plugin.QueryData, _ *plugin.
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.CoreV1().ServiceAccounts("").List(ctx, input)
+		response, err = clientset.CoreV1().ServiceAccounts(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/table_kubernetes_stateful_set.go
+++ b/kubernetes/table_kubernetes_stateful_set.go
@@ -211,7 +211,7 @@ func listK8sStatefulSets(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.AppsV1().StatefulSets("").List(ctx, input)
+		response, err = clientset.AppsV1().StatefulSets(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			return nil, err
 		}

--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -636,10 +636,6 @@ func getCommonOptionalKeyQualsValueForFieldSelector(d *plugin.QueryData) []strin
 		fieldSelectors = append(fieldSelectors, fmt.Sprintf("metadata.name=%v", d.EqualsQualString("name")))
 	}
 
-	if d.EqualsQualString("namespace") != "" {
-		fieldSelectors = append(fieldSelectors, fmt.Sprintf("metadata.namespace=%v", d.EqualsQualString("namespace")))
-	}
-
 	return fieldSelectors
 }
 


### PR DESCRIPTION
This PR makes the plugin pass the namespace qualifier to the kubernetes API client when querying namespace scoped resources.