### PR TITLE
Update API version for the kubernetes_horizontal_pod_autoscaler table

### DIFF
--- a/kubernetes/table_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/table_kubernetes_horizontal_pod_autoscaler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	v1 "k8s.io/api/autoscaling/v1"
+	v2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
@@ -130,7 +130,7 @@ func tableKubernetesHorizontalPodAutoscaler(ctx context.Context) *plugin.Table {
 }
 
 type HorizontalPodAutoscaler struct {
-	v1.HorizontalPodAutoscaler
+	v2.HorizontalPodAutoscaler
 	parsedContent
 }
 
@@ -152,7 +152,7 @@ func listK8sHPAs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	}
 
 	for _, content := range parsedContents {
-		hpa := content.ParsedData.(*v1.HorizontalPodAutoscaler)
+		hpa := content.ParsedData.(*v2.HorizontalPodAutoscaler)
 
 		d.StreamListItem(ctx, HorizontalPodAutoscaler{*hpa, content})
 
@@ -189,11 +189,11 @@ func listK8sHPAs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 		input.FieldSelector = strings.Join(commonFieldSelectorValue, ",")
 	}
 
-	var response *v1.HorizontalPodAutoscalerList
+	var response *v2.HorizontalPodAutoscalerList
 	pageLeft := true
 
 	for pageLeft {
-		response, err = clientset.AutoscalingV1().HorizontalPodAutoscalers(d.EqualsQualString("namespace")).List(ctx, input)
+		response, err = clientset.AutoscalingV2().HorizontalPodAutoscalers(d.EqualsQualString("namespace")).List(ctx, input)
 		if err != nil {
 			plugin.Logger(ctx).Error("listK8sHPAs", "api_err", err)
 			return nil, err
@@ -242,7 +242,7 @@ func getK8sHPA(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 	}
 
 	for _, content := range parsedContents {
-		hpa := content.ParsedData.(*v1.HorizontalPodAutoscaler)
+		hpa := content.ParsedData.(*v2.HorizontalPodAutoscaler)
 
 		if hpa.Name == name && hpa.Namespace == namespace {
 			return HorizontalPodAutoscaler{*hpa, content}, nil
@@ -254,7 +254,7 @@ func getK8sHPA(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 		return nil, nil
 	}
 
-	hpa, err := clientset.AutoscalingV1().HorizontalPodAutoscalers(namespace).Get(ctx, name, metav1.GetOptions{})
+	hpa, err := clientset.AutoscalingV2().HorizontalPodAutoscalers(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil && !isNotFoundError(err) {
 		plugin.Logger(ctx).Error("getK8sHPA", "api_err", err)
 		return nil, err


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, jsonb_pretty(metrics),scale_up_behavior, scale_down_behavior, jsonb_pretty(current_metrics), conditions from kubernetes_horizontal_pod_autoscaler
+------------+------------------------------------------+-------------------+---------------------+-----------------------------------------+------------------------------------------------------------------------>
| name       | jsonb_pretty                             | scale_up_behavior | scale_down_behavior | jsonb_pretty                            | conditions                                                             >
+------------+------------------------------------------+-------------------+---------------------+-----------------------------------------+------------------------------------------------------------------------>
| php-apache | [                                        | <null>            | <null>              | [                                       | [{"lastTransitionTime":"2023-11-07T11:38:48Z","message":"recommended si>
|            |     {                                    |                   |                     |     {                                   |                                                                        >
|            |         "type": "Resource",              |                   |                     |         "type": "Resource",             |                                                                        >
|            |         "resource": {                    |                   |                     |         "resource": {                   |                                                                        >
|            |             "name": "cpu",               |                   |                     |             "name": "cpu",              |                                                                        >
|            |             "target": {                  |                   |                     |             "current": {                |                                                                        >
|            |                 "type": "Utilization",   |                   |                     |                 "value": "7m",          |                                                                        >
|            |                 "averageUtilization": 50 |                   |                     |                 "averageValue": "7m",   |                                                                        >
|            |             }                            |                   |                     |                 "averageUtilization": 4 |                                                                        >
|            |         }                                |                   |                     |             }                           |                                                                        >
|            |     }                                    |                   |                     |         }                               |                                                                        >
|            | ]                                        |                   |                     |     }                                   |                                                                        >
|            |                                          |                   |                     | ]                                       |                                                                        >
+------------+------------------------------------------+-------------------+---------------------+-----------------------------------------+------------------------------------------------------------------------>

```
</details>
