### PR TITLE
Create tables with fully qualified name for custom resources

### DIFF
--- a/docs/tables/kubernetes_{custom_resource_singular_name}.md
+++ b/docs/tables/kubernetes_{custom_resource_singular_name}.md
@@ -13,7 +13,7 @@ The `kubernetes_{custom_resource_singular_name}` table provides insights into th
 
 Query data from the custom resource called `kubernetes_{custom_resource_singular_name}`, e.g., `kubernetes_certificate`, `kubernetes_capacityrequest`. A table is automatically created to represent each custom resource.
 
-If the table name is already created in the above format and exists in the table list, then the subsequent ones will have the fully qualified name `kubernetes_{custom_resource_singular_name}_{custom_resource_group_name}`, e.g., `kubernetes_certificate_cert_manager_io`.
+If multiple custom resources share the same singular name, you can query the data using their table fully qualified name `kubernetes_{custom_resource_singular_name}_{custom_resource_group_name}`, e.g., `kubernetes_certificate_cert_manager_io`.
 
 For instance, given the CRD `certManager.yaml`:
 

--- a/kubernetes/plugin.go
+++ b/kubernetes/plugin.go
@@ -123,10 +123,9 @@ func pluginTableDefinitions(ctx context.Context, d *plugin.TableMapData) (map[st
 		if tables["kubernetes_"+crd.Spec.Names.Singular] == nil {
 			ctx = context.WithValue(ctx, contextKey("TableName"), "kubernetes_"+crd.Spec.Names.Singular)
 			tables["kubernetes_"+crd.Spec.Names.Singular] = tableKubernetesCustomResource(ctx)
-		} else {
-			ctx = context.WithValue(ctx, contextKey("TableName"), "kubernetes_"+crd.Spec.Names.Singular+"_"+re.ReplaceAllString(crd.Spec.Group, "_"))
-			tables["kubernetes_"+crd.Spec.Names.Singular+"_"+re.ReplaceAllString(crd.Spec.Group, "_")] = tableKubernetesCustomResource(ctx)
 		}
+		ctx = context.WithValue(ctx, contextKey("TableName"), "kubernetes_"+crd.Spec.Names.Singular+"_"+re.ReplaceAllString(crd.Spec.Group, "_"))
+		tables["kubernetes_"+crd.Spec.Names.Singular+"_"+re.ReplaceAllString(crd.Spec.Group, "_")] = tableKubernetesCustomResource(ctx)
 	}
 
 	return tables, nil


### PR DESCRIPTION
**Changes:**
Creating tables for custom resources with fully qualified name even there is no collisions. This will help to query exact CR if there are multiple resources with the same singular name.
