### PR TITLE
fix inconsistent columns

### DIFF
--- a/kubernetes/table_kubernetes_custom_resource.go
+++ b/kubernetes/table_kubernetes_custom_resource.go
@@ -50,9 +50,9 @@ func getCustomResourcesDynamicColumns(ctx context.Context, versionSchemaSpec int
 	allColumns := []string{"name", "uid", "kind", "api_version", "namespace", "creation_timestamp", "labels", "start_line", "end_line", "path", "source_type", "annotations", "context_name"}
 
 	// add the spec columns
-	flag := 0
 	schemaSpec := versionSchemaSpec.(v1.JSONSchemaProps)
 	for k, v := range schemaSpec.Properties {
+		flag := 0
 		for _, specColumn := range allColumns {
 			if specColumn == strcase.ToSnake(k) {
 				flag = 1
@@ -78,9 +78,9 @@ func getCustomResourcesDynamicColumns(ctx context.Context, versionSchemaSpec int
 	}
 
 	// add the status columns
-	flag = 0
 	schemaStatus := versionSchemaStatus.(v1.JSONSchemaProps)
 	for k, v := range schemaStatus.Properties {
+		flag := 0
 		for _, statusColumn := range allColumns {
 			if statusColumn == strcase.ToSnake(k) {
 				flag = 1


### PR DESCRIPTION
fix #227 [Inconsistent DDL (Column order changes, and some columns are intermittently missing)]

To facilitate comparison, I  inserted the following code in [here](https://github.com/turbot/steampipe-plugin-kubernetes/blob/main/kubernetes/plugin.go#L117) temporarily.

```go
		if strings.Contains(crd.Spec.Names.Singular, "nodeclass") {
			a := tableKubernetesCustomResource(ctx)
			columnNames := []string{}
			for _, column := range a.Columns {
				columnNames = append(columnNames, column.Name)
			}
			sort.Strings(columnNames)
			plugin.Logger(ctx).Warn("tableKubernetesCustomResource", columnNames)
		}
```

And the following is a comparison of the logs before and after applying the PR.

**[as-is]**

```
❯ tail -f ~/.steampipe/logs/plugin-2024-05-31.log                                                                                    14:13:39
2024-05-31 05:13:49.861 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "tags", "uid", "user_data"]
2024-05-31 05:13:51.633 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "tags", "uid", "user_data"]
2024-05-31 05:13:53.146 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "security_groups", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
2024-05-31 05:14:15.870 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
2024-05-31 05:14:18.176 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "tags", "uid", "user_data"]
2024-05-31 05:14:19.661 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "security_groups", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
2024-05-31 05:14:38.304 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
2024-05-31 05:14:39.948 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "tags", "uid", "user_data"]
2024-05-31 05:14:41.907 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "tags", "uid", "user_data"]
```

**[to-be]**

```
❯ tail -f ~/.steampipe/logs/plugin-2024-05-31.log                                                                                    14:16:15
2024-05-31 05:16:18.823 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "security_groups", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
2024-05-31 05:16:21.244 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "security_groups", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
2024-05-31 05:16:22.985 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "security_groups", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
2024-05-31 05:16:34.780 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "security_groups", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
2024-05-31 05:16:36.720 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "security_groups", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
2024-05-31 05:16:39.425 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "security_groups", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
2024-05-31 05:16:49.373 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "security_groups", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
2024-05-31 05:16:51.133 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "security_groups", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
2024-05-31 05:16:52.750 UTC [WARN]  steampipe-plugin-kubernetes.plugin: [WARN]  tableKubernetesCustomResource: EXTRA_VALUE_AT_END=["ami_family", "ami_selector_terms", "amis", "annotations", "api_version", "block_device_mappings", "context", "context_name", "creation_timestamp", "detailed_monitoring", "end_line", "instance_profile", "instance_store_policy", "kind", "labels", "metadata_options", "name", "namespace", "path", "role", "security_group_selector_terms", "security_groups", "source_type", "start_line", "status_instance_profile", "subnet_selector_terms", "subnets", "tags", "uid", "user_data"]
```

I also confirmed consistent results in both Steampipe and DataGrip after testing eight times on three clusters.

I couldn't run the tests because I didn't know how to do them. If you have any instructions, please let me know!