### PR TITLE
Use default timeout for listing CRDs

### DIFF
--- a/kubernetes/plugin.go
+++ b/kubernetes/plugin.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/turbot/go-kit/helpers"
-	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/v5/connection"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -187,19 +186,18 @@ func listK8sDynamicCRDs(ctx context.Context, cn *connection.ConnectionCache, c *
 	// the deployed resources are not expected when the source_type is "manifest".
 	if clientset != nil {
 		input := metav1.ListOptions{
-			Limit:          500,
-			TimeoutSeconds: types.Int64(5),
+			Limit: 500,
 		}
 
 		pageLeft := true
 		for pageLeft {
 			response, err := clientset.ApiextensionsV1().CustomResourceDefinitions().List(ctx, input)
 			if err != nil {
+				plugin.Logger(ctx).Error("listK8sDynamicCRDs", "list_err", err)
 				// At the plugin load time, if the config is not setup properly, return nil
 				if strings.Contains(err.Error(), "/apis/apiextensions.k8s.io/v1/customresourcedefinitions?limit=500") {
 					return nil, nil
 				}
-				plugin.Logger(ctx).Error("listK8sDynamicCRDs", "list_err", err)
 				return nil, err
 			}
 


### PR DESCRIPTION
**Plugin Version:** 0.28.0

### Problem
Listing Custom Resource Definitions (CRDs) fails on large clusters.

### Investigation
On a large cluster with over 2000 CRDs, we observed that the command `.inspect kubernetes` did not create tables for custom resource definitions. While all other tables were created successfully, CRD tables were missing. 

No errors were found in the logs, so we modified the code to print the error at [this location](https://github.com/turbot/steampipe-plugin-kubernetes/blob/main/kubernetes/plugin.go#L197). This revealed that there was a silent timeout during the listing of custom resources, with no error logs or codes returned.

### Fix

1. **Remove Custom Timeout:** Reverted to using the default timeout same as specified [here](https://github.com/turbot/steampipe-plugin-kubernetes/blob/main/kubernetes/table_kubernetes_custom_resource_definition.go#L87).
2. **Enhanced Observability:** Added error message printing to ensure any issues are logged.
