### PR TITLE
Expand kubernetes_node and kubernetes_pod tables with cpu and memory information using a normalized unit Closes #242

### DIFF
--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -994,4 +995,71 @@ func keysToSnakeCase(_ context.Context, d *transform.TransformData) (interface{}
 		snakes = append(snakes, re.ReplaceAllString(k, "_"))
 	}
 	return strings.Join(snakes, "."), nil
+}
+
+// normalizeCPUToMilliCores converts CPU quantities to millicores (m), rounding up if necessary.
+func normalizeCPUToMilliCores(cpu string) (int64, error) {
+	if strings.HasSuffix(cpu, "m") {
+		// Already in millicores
+		value, err := strconv.ParseFloat(strings.TrimSuffix(cpu, "m"), 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid CPU value: %s", cpu)
+		}
+		return int64(math.Ceil(value)), nil
+	}
+
+	// Convert cores to millicores
+	value, err := strconv.ParseFloat(cpu, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid CPU value: %s", cpu)
+	}
+
+	milliCores := value * 1000
+	return int64(math.Ceil(milliCores)), nil
+}
+
+// normalizeMemoryToBytes converts memory quantities to bytes, rounding up if necessary.
+func normalizeMemoryToBytes(memory string) (int64, error) {
+	var valuePart, unitPart string
+	for i, r := range memory {
+		if r < '0' || r > '9' {
+			valuePart = memory[:i]
+			unitPart = memory[i:]
+			break
+		}
+	}
+	if valuePart == "" {
+		return 0, fmt.Errorf("invalid memory value: %s", memory)
+	}
+
+	value, err := strconv.ParseFloat(valuePart, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid memory value: %s", memory)
+	}
+
+	unitPart = strings.TrimSpace(unitPart)
+	multiplier, exists := memoryUnits[unitPart]
+	if !exists {
+		return 0, fmt.Errorf("unknown unit: %s", unitPart)
+	}
+
+	bytes := value * multiplier
+	return int64(math.Ceil(bytes)), nil
+}
+
+// Unit multipliers for memory
+var memoryUnits = map[string]float64{
+	"B":  1,
+	"Ki": math.Pow(2, 10),
+	"Mi": math.Pow(2, 20),
+	"Gi": math.Pow(2, 30),
+	"Ti": math.Pow(2, 40),
+	"Pi": math.Pow(2, 50),
+	"Ei": math.Pow(2, 60),
+	"k":  1e3,
+	"M":  1e6,
+	"G":  1e9,
+	"T":  1e12,
+	"P":  1e15,
+	"E":  1e18,
 }


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, namespace, jsonb_pretty(containers_resources_limits_std), jsonb_pretty(containers_resources_requests_std) from kubernetes_pod
+----------------------------------+-------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------+
| name                             | namespace   | jsonb_pretty                                                                | jsonb_pretty                                                                |
+----------------------------------+-------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------+
| coredns-6f6b679f8f-v2fqq         | kube-system | [                                                                           | [                                                                           |
|                                  |             |     {                                                                       |     {                                                                       |
|                                  |             |         "memory": 178257920,                                                |         "cpu": 100,                                                         |
|                                  |             |         "containerName": "coredns",                                         |         "memory": 73400320,                                                 |
|                                  |             |         "containerImage": "registry.k8s.io/coredns/coredns:v1.11.1"         |         "containerName": "coredns",                                         |
|                                  |             |     }                                                                       |         "containerImage": "registry.k8s.io/coredns/coredns:v1.11.1"         |
|                                  |             | ]                                                                           |     }                                                                       |
|                                  |             |                                                                             | ]                                                                           |
| kube-controller-manager-minikube | kube-system | [                                                                           | [                                                                           |
|                                  |             |     {                                                                       |     {                                                                       |
|                                  |             |         "containerName": "kube-controller-manager",                         |         "cpu": 200,                                                         |
|                                  |             |         "containerImage": "registry.k8s.io/kube-controller-manager:v1.31.0" |         "containerName": "kube-controller-manager",                         |
|                                  |             |     }                                                                       |         "containerImage": "registry.k8s.io/kube-controller-manager:v1.31.0" |
|                                  |             | ]                                                                           |     }                                                                       |
|                                  |             |                                                                             | ]                                                                           |
| storage-provisioner              | kube-system | [                                                                           | [                                                                           |
|                                  |             |     {                                                                       |     {                                                                       |
|                                  |             |         "containerName": "storage-provisioner",                             |         "containerName": "storage-provisioner",                             |
|                                  |             |         "containerImage": "gcr.io/k8s-minikube/storage-provisioner:v5"      |         "containerImage": "gcr.io/k8s-minikube/storage-provisioner:v5"      |
|                                  |             |     }                                                                       |     }                                                                       |
|                                  |             | ]                                                                           | ]                                                                           |
| kube-apiserver-minikube          | kube-system | [                                                                           | [                                                                           |
|                                  |             |     {                                                                       |     {                                                                       |
|                                  |             |         "containerName": "kube-apiserver",                                  |         "cpu": 250,                                                         |
|                                  |             |         "containerImage": "registry.k8s.io/kube-apiserver:v1.31.0"          |         "containerName": "kube-apiserver",                                  |
|                                  |             |     }                                                                       |         "containerImage": "registry.k8s.io/kube-apiserver:v1.31.0"          |
|                                  |             | ]                                                                           |     }                                                                       |
|                                  |             |                                                                             | ]                                                                           |
| kube-proxy-jzbmg                 | kube-system | [                                                                           | [                                                                           |
|                                  |             |     {                                                                       |     {                                                                       |
|                                  |             |         "containerName": "kube-proxy",                                      |         "containerName": "kube-proxy",                                      |
|                                  |             |         "containerImage": "registry.k8s.io/kube-proxy:v1.31.0"              |         "containerImage": "registry.k8s.io/kube-proxy:v1.31.0"              |
|                                  |             |     }                                                                       |     }                                                                       |
|                                  |             | ]                                                                           | ]                                                                           |
| etcd-minikube                    | kube-system | [                                                                           | [                                                                           |
|                                  |             |     {                                                                       |     {                                                                       |
|                                  |             |         "containerName": "etcd",                                            |         "cpu": 100,                                                         |
|                                  |             |         "containerImage": "registry.k8s.io/etcd:3.5.15-0"                   |         "memory": 104857600,                                                |
|                                  |             |     }                                                                       |         "containerName": "etcd",                                            |
|                                  |             | ]                                                                           |         "containerImage": "registry.k8s.io/etcd:3.5.15-0"                   |
|                                  |             |                                                                             |     }                                                                       |
|                                  |             |                                                                             | ]                                                                           |
| kube-scheduler-minikube          | kube-system | [                                                                           | [                                                                           |
|                                  |             |     {                                                                       |     {                                                                       |
|                                  |             |         "containerName": "kube-scheduler",                                  |         "cpu": 100,                                                         |
|                                  |             |         "containerImage": "registry.k8s.io/kube-scheduler:v1.31.0"          |         "containerName": "kube-scheduler",                                  |
|                                  |             |     }                                                                       |         "containerImage": "registry.k8s.io/kube-scheduler:v1.31.0"          |
|                                  |             | ]                                                                           |     }                                                                       |
|                                  |             |                                                                             | ]                                                                           |
+----------------------------------+-------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------+

```

```
> select name,capacity_cpu, capacity_cpu_std,capacity_memory, capacity_memory_std,allocatable_cpu, allocatable_memory, allocatable_cpu_std, allocatable_memory_std, jsonb_pretty(capacity), jsonb_pretty(allocatable) from kubernetes_node
+----------+--------------+------------------+-----------------+---------------------+-----------------+--------------------+---------------------+------------------------+---------------------------------------+---------------------------------------+
| name     | capacity_cpu | capacity_cpu_std | capacity_memory | capacity_memory_std | allocatable_cpu | allocatable_memory | allocatable_cpu_std | allocatable_memory_std | jsonb_pretty                          | jsonb_pretty                          |
+----------+--------------+------------------+-----------------+---------------------+-----------------+--------------------+---------------------+------------------------+---------------------------------------+---------------------------------------+
| minikube | 11           | 11000            | 8026752Ki       | 8219394048          | 11              | 8026752Ki          | 11000               | 8219394048             | {                                     | {                                     |
|          |              |                  |                 |                     |                 |                    |                     |                        |     "cpu": "11",                      |     "cpu": "11",                      |
|          |              |                  |                 |                     |                 |                    |                     |                        |     "pods": "110",                    |     "pods": "110",                    |
|          |              |                  |                 |                     |                 |                    |                     |                        |     "memory": "8026752Ki",            |     "memory": "8026752Ki",            |
|          |              |                  |                 |                     |                 |                    |                     |                        |     "hugepages-1Gi": "0",             |     "hugepages-1Gi": "0",             |
|          |              |                  |                 |                     |                 |                    |                     |                        |     "hugepages-2Mi": "0",             |     "hugepages-2Mi": "0",             |
|          |              |                  |                 |                     |                 |                    |                     |                        |     "hugepages-32Mi": "0",            |     "hugepages-32Mi": "0",            |
|          |              |                  |                 |                     |                 |                    |                     |                        |     "hugepages-64Ki": "0",            |     "hugepages-64Ki": "0",            |
|          |              |                  |                 |                     |                 |                    |                     |                        |     "ephemeral-storage": "61202244Ki" |     "ephemeral-storage": "61202244Ki" |
|          |              |                  |                 |                     |                 |                    |                     |                        | }                                     | }                                     |
+----------+--------------+------------------+-----------------+---------------------+-----------------+--------------------+---------------------+------------------------+---------------------------------------+---------------------------------------+
```

</details>
