### PR TITLE
handling memory normalization when only bytes are passed

### DIFF
--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -1020,7 +1020,9 @@ func normalizeCPUToMilliCores(cpu string) (int64, error) {
 
 // normalizeMemoryToBytes converts memory quantities to bytes, rounding up if necessary.
 func normalizeMemoryToBytes(memory string) (int64, error) {
-	var valuePart, unitPart string
+	// Set default value to arg value and unit to Bytes
+	valuePart := memory
+	unitPart := "B"
 	for i, r := range memory {
 		if r < '0' || r > '9' {
 			valuePart = memory[:i]


### PR DESCRIPTION
the if condition doesn't handle the case when the memory string is comprised only of digits (which is number of bytes). to handle this, the initial value of valuePart and unitPart is set to this case, if there are letters in the string, the matching values will be set accordingly.

initially got error:
Error: kubernetes: failed to populate column 'containers_resources_requests_std': invalid memory value: 1288490189 (SQLSTATE HV000)

And now, followed the guidelines to test it locally, and it worked for me :)
