### PR TITLE
adding missing memory unit to map

### DIFF
--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -1051,6 +1051,7 @@ func normalizeMemoryToBytes(memory string) (int64, error) {
 
 // Unit multipliers for memory
 var memoryUnits = map[string]float64{
+	"m":  1e-3,
 	"B":  1,
 	"Ki": math.Pow(2, 10),
 	"Mi": math.Pow(2, 20),


### PR DESCRIPTION
According to official docs: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
The memory units include lower-case 'm' which is a "millibyte" or "one thousandth of a byte". This unit is missing from the map which results in the following error:
```
> select name,namespace,node_name from conn.kubernetes_pod

Error: conn: failed to populate column 'containers_resources_requests_std': unknown unit: m (SQLSTATE HV000)
```
