### PR TITLE
add selector, selector_query to statful_set

### DIFF
--- a/k8s-test/tests/kubernetes_stateful_set/test-get-expected.json
+++ b/k8s-test/tests/kubernetes_stateful_set/test-get-expected.json
@@ -8,6 +8,12 @@
 		"pod_management_policy": "OrderedReady",
 		"ready_replicas": 2,
 		"replicas": 2,
+		"selector": {
+			"matchLabels": {
+				"app": "nginx"
+			}
+		},
+		"selector_query": "app=nginx",
 		"revision_history_limit": 10,
 		"service_name": "nginx",
 		"update_strategy": {

--- a/k8s-test/tests/kubernetes_stateful_set/test-get-query.sql
+++ b/k8s-test/tests/kubernetes_stateful_set/test-get-query.sql
@@ -3,6 +3,8 @@ select
   namespace,
   service_name,
   replicas,
+  selector,
+  selector_query,
   collision_count,
   current_replicas,
   observed_generation,

--- a/kubernetes/table_kubernetes_stateful_set.go
+++ b/kubernetes/table_kubernetes_stateful_set.go
@@ -39,6 +39,18 @@ func tableKubernetesStatefulSet(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("Spec.Replicas"),
 			},
 			{
+				Name:        "selector_query",
+				Type:        proto.ColumnType_STRING,
+				Description: "A query string representation of the selector.",
+				Transform:   transform.FromField("Spec.Selector").Transform(labelSelectorToString),
+			},
+			{
+				Name:        "selector",
+				Type:        proto.ColumnType_JSON,
+				Description: "Label selector for pods. A label selector is a label query over a set of resources.",
+				Transform:   transform.FromField("Spec.Selector"),
+			},
+			{
 				Name:        "collision_count",
 				Type:        proto.ColumnType_INT,
 				Description: "The count of hash collisions for the StatefulSet.",


### PR DESCRIPTION
<details>
  <summary>Example query results</summary>
  
```
> select name, selector_query, selector from k8s_main.kubernetes_stateful_set limit 3;
+--------------------------+---------------------------------------------------------+---------------------------------------------------------------------------------------+
| name                     | selector_query                                          | selector                                                                              |
+--------------------------+---------------------------------------------------------+---------------------------------------------------------------------------------------+
| devops-airflow-redis     | component=redis,release=devops-airflow,tier=airflow     | {"matchLabels":{"component":"redis","release":"devops-airflow","tier":"airflow"}}     |
| devops-airflow-triggerer | component=triggerer,release=devops-airflow,tier=airflow | {"matchLabels":{"component":"triggerer","release":"devops-airflow","tier":"airflow"}} |
| devops-airflow-worker    | component=worker,release=devops-airflow,tier=airflow    | {"matchLabels":{"component":"worker","release":"devops-airflow","tier":"airflow"}}    |
+--------------------------+---------------------------------------------------------+---------------------------------------------------------------------------------------+
```
</details>


This field was originally only in the deployment table. I copied it to statefulsets without changes because it works the same way there.

I think this field can be useful when mapping it with selectors from other workloads, like we do with PDB.

For my use case, I look at the PDB's minAvailable and maxUnavailable settings together with the workload's replicas to find misconfigurations that might prevent node rollouts.