### PR TITLE
Fixed error in kubernetes_pod table when using scientific notation for pod resource requests/limits Closes #314

### DIFF
--- a/kubernetes/table_kubernetes_pod.go
+++ b/kubernetes/table_kubernetes_pod.go
@@ -618,14 +618,14 @@ func transformPodCpuAndMemoryUnit(ctx context.Context, d *transform.TransformDat
 
 	if param == "limit" {
 		limitCPUMemoryMaps := make([]map[string]interface{}, 0)
-	
-		limitCPUMemoryMap := make(map[string]interface{})
-	
+
 		for _, container := range containers {
+			// Create a new map for each container
+			limitCPUMemoryMap := make(map[string]interface{})
 			limit := container.Resources.Limits
 			limitCPUMemoryMap["containerName"] = container.Name
 			limitCPUMemoryMap["containerImage"] = container.Image
-			if limit.Cpu().String() != "" && !limit.Cpu().IsZero(){
+			if limit.Cpu().String() != "" && !limit.Cpu().IsZero() {
 				cpu, err := normalizeCPUToMilliCores(limit.Cpu().String())
 				if err != nil {
 					plugin.Logger(ctx).Error("kubernetes_pod.transformPodCpuAndMemoryUnit", "error in parsing the CPU value", err)
@@ -633,8 +633,8 @@ func transformPodCpuAndMemoryUnit(ctx context.Context, d *transform.TransformDat
 				}
 				limitCPUMemoryMap["cpu"] = cpu
 			}
-	
-			if limit.Memory().String() != "" && !limit.Memory().IsZero(){
+
+			if limit.Memory().String() != "" && !limit.Memory().IsZero() {
 				memory, err := normalizeMemoryToBytes(limit.Memory().String())
 				if err != nil {
 					plugin.Logger(ctx).Error("kubernetes_pod.transformPodCpuAndMemoryUnit", "error in parsing the memory value", err)
@@ -643,20 +643,19 @@ func transformPodCpuAndMemoryUnit(ctx context.Context, d *transform.TransformDat
 				limitCPUMemoryMap["memory"] = memory
 			}
 			limitCPUMemoryMaps = append(limitCPUMemoryMaps, limitCPUMemoryMap)
-	
 		}
 
 		return limitCPUMemoryMaps, nil
 	} else if param == "request" {
 		requestCPUMemoryMaps := make([]map[string]interface{}, 0)
-	
-		requestCPUMemoryMap := make(map[string]interface{})
-	
+
 		for _, container := range containers {
+			// Create a new map for each container
+			requestCPUMemoryMap := make(map[string]interface{})
 			request := container.Resources.Requests
 			requestCPUMemoryMap["containerName"] = container.Name
 			requestCPUMemoryMap["containerImage"] = container.Image
-			if request.Cpu().String() != "" && !request.Cpu().IsZero(){
+			if request.Cpu().String() != "" && !request.Cpu().IsZero() {
 				cpu, err := normalizeCPUToMilliCores(request.Cpu().String())
 				if err != nil {
 					plugin.Logger(ctx).Error("kubernetes_pod.transformPodCpuAndMemoryUnit", "error in parsing the CPU value", err)
@@ -664,8 +663,8 @@ func transformPodCpuAndMemoryUnit(ctx context.Context, d *transform.TransformDat
 				}
 				requestCPUMemoryMap["cpu"] = cpu
 			}
-	
-			if request.Memory().String() != "" && !request.Memory().IsZero(){
+
+			if request.Memory().String() != "" && !request.Memory().IsZero() {
 				memory, err := normalizeMemoryToBytes(request.Memory().String())
 				if err != nil {
 					plugin.Logger(ctx).Error("kubernetes_pod.transformPodCpuAndMemoryUnit", "error in parsing the memory value", err)
@@ -674,7 +673,6 @@ func transformPodCpuAndMemoryUnit(ctx context.Context, d *transform.TransformDat
 				requestCPUMemoryMap["memory"] = memory
 			}
 			requestCPUMemoryMaps = append(requestCPUMemoryMaps, requestCPUMemoryMap)
-	
 		}
 
 		return requestCPUMemoryMaps, nil


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from kubernetes_pod
+----------------------------------+-------------+--------------------------------------+-----------------+------------------------------------------------------------------->
| name                             | namespace   | uid                                  | selector_search | volumes                                                           >
+----------------------------------+-------------+--------------------------------------+-----------------+------------------------------------------------------------------->
| kube-apiserver-minikube          | kube-system | c902e731-fa72-44af-b565-0965f37c3881 | <null>          | [{"hostPath":{"path":"/etc/ssl/certs","type":"DirectoryOrCreate"},>
|                                  |             |                                      |                 |                                                                   >
|                                  |             |                                      |                 |                                                                   >
| hello-world-pod-1                | default     | 094f579d-3461-4cb1-a56c-98819899f158 | <null>          | [{"name":"kube-api-access-x9v2g","projected":{"defaultMode":420,"s>
| coredns-6f6b679f8f-96jgg         | kube-system | 48a4d4b1-1623-454f-8221-4168409f0d0c | <null>          | [{"configMap":{"defaultMode":420,"items":[{"key":"Corefile","path">
|                                  |             |                                      |                 |                                                                   >
| kube-controller-manager-minikube | kube-system | 8535ce7c-1503-4df6-a51c-55e63f524ae2 | <null>          | [{"hostPath":{"path":"/etc/ssl/certs","type":"DirectoryOrCreate"},>
|                                  |             |                                      |                 |                                                                   >
|                                  |             |                                      |                 |                                                                   >
| kube-scheduler-minikube          | kube-system | 68641490-ae63-4ec7-96e9-016970067933 | <null>          | [{"hostPath":{"path":"/etc/kubernetes/scheduler.conf","type":"File>
| etcd-minikube                    | kube-system | debcc039-0976-4e0f-ba80-472bbb73d759 | <null>          | [{"hostPath":{"path":"/var/lib/minikube/certs/etcd","type":"Dire

> select * from kubernetes_node
+----------+--------------------------------------+---------------+-------------------+-------------+---------------+--------+---------------+--------------+----------------->
| name     | uid                                  | pod_cidr      | pod_cidrs         | provider_id | unschedulable | taints | config_source | capacity_cpu | capacity_memory >
+----------+--------------------------------------+---------------+-------------------+-------------+---------------+--------+---------------+--------------+----------------->
| minikube | 037a100a-45cc-4f9d-89f8-cbddc89de0f0 | 10.244.0.0/24 | ["10.244.0.0/24"] |             | false         | <null> | <null>        | 11           | 8025220Ki       >
|          |                                      |               |                   |             |               |        |               |              |                 >
+----------+--------------------------------------+---------------+-------------------+-------------+---------------+--------+---------------+--------------+---------------
```
</details>
