### PR TITLE
feat: add support for .report root field in CRD plugin

### DIFF
--- a/kubernetes/table_kubernetes_custom_resource.go
+++ b/kubernetes/table_kubernetes_custom_resource.go
@@ -25,6 +25,7 @@ func tableKubernetesCustomResource(ctx context.Context) *plugin.Table {
 	activeVersion := ctx.Value(contextKey("ActiveVersion")).(string)
 	versionSchemaSpec := ctx.Value(contextKey("VersionSchemaSpec"))
 	versionSchemaStatus := ctx.Value(contextKey("VersionSchemaStatus"))
+	versionSchemaReport := ctx.Value(contextKey("VersionSchemaReport"))
 	tableName := ctx.Value(contextKey("TableName")).(string)
 
 	var description string
@@ -39,11 +40,11 @@ func tableKubernetesCustomResource(ctx context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listK8sCustomResources(ctx, crdName, resourceName, resourceNameSingular, groupName, activeVersion),
 		},
-		Columns: k8sCRDResourceCommonColumns(getCustomResourcesDynamicColumns(ctx, versionSchemaSpec, versionSchemaStatus)),
+		Columns: k8sCRDResourceCommonColumns(getCustomResourcesDynamicColumns(ctx, versionSchemaSpec, versionSchemaStatus, versionSchemaReport)),
 	}
 }
 
-func getCustomResourcesDynamicColumns(ctx context.Context, versionSchemaSpec interface{}, versionSchemaStatus interface{}) []*plugin.Column {
+func getCustomResourcesDynamicColumns(ctx context.Context, versionSchemaSpec interface{}, versionSchemaStatus interface{},versionSchemaReport interface{}) []*plugin.Column {
 	columns := []*plugin.Column{}
 
 	// default metadata columns
@@ -103,7 +104,32 @@ func getCustomResourcesDynamicColumns(ctx context.Context, versionSchemaSpec int
 			columns = append(columns, column)
 		}
 	}
-
+	// add the report columns
+	schemaReport := versionSchemaReport.(v1.JSONSchemaProps)
+	for k, v := range schemaReport.Properties {
+		flag := 0
+		for _, reportColumn := range allColumns {
+			if reportColumn == strcase.ToSnake(k) {
+				flag = 1
+				column := &plugin.Column{
+					Name:        "report_" + strcase.ToSnake(k),
+					Description: v.Description,
+					Transform:   transform.FromP(extractReportProperty, k),
+				}
+				setDynamicColumns(v, column)
+				columns = append(columns, column)
+			}
+		}
+		if flag == 0 {
+			column := &plugin.Column{
+				Name:        strcase.ToSnake(k),
+				Description: v.Description,
+				Transform:   transform.FromP(extractReportProperty, k),
+			}
+			setDynamicColumns(v, column)
+			columns = append(columns, column)
+		}
+	}
 	return columns
 }
 
@@ -252,11 +278,19 @@ func extractStatusProperty(_ context.Context, d *transform.TransformData) (inter
 	if status[param] != nil {
 		return status[param], nil
 	}
+	return nil, nil
+}
+
+func extractReportProperty(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	ob := d.HydrateItem.(*CRDResourceInfo).Report
+	if ob == nil {
+		return nil, nil
+	}
+	param := d.Param.(string)
 	report := ob.(map[string]interface{})
 	if report[param] != nil {
 		return report[param], nil
 	}
-
 	return nil, nil
 }
 


### PR DESCRIPTION
This PR introduces support for the .report root field in the CRD plugin for Steampipe.

Changes:
Implemented parsing and handling of the .report root field in custom resource definitions.

Added logic to expose this data in the table schema.

Performed manual testing to validate expected behavior on sample CRDs.

<img width="1147" height="123" alt="image" src="https://github.com/user-attachments/assets/0c318809-c19e-438c-9168-5366ce480b22" />

<img width="348" height="418" alt="image" src="https://github.com/user-attachments/assets/ea0e40d7-8332-41a6-9bf1-0a036c597e00" />

This addition helps expose more structured insights from CRDs with .report fields, improving visibility for policy and compliance checks.
