### PR TITLE
feat: support inline kubeconfig in `config_path`

### DIFF
--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -546,25 +546,21 @@ func tryInlineKubeconfig(configPath string, configContext *string) (clientcmd.Cl
 		return nil, false, nil
 	}
 
-	// Inline kubeconfig YAML — parse directly, zero disk I/O
-	overrides := &clientcmd.ConfigOverrides{}
-	if configContext != nil {
-		overrides.CurrentContext = *configContext
-		overrides.Context = clientcmdapi.Context{}
-	}
-
 	kubeconfig, err := clientcmd.NewClientConfigFromBytes([]byte(configPath))
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to parse inline kubeconfig from config_path: %w", err)
 	}
 
-	// Apply context override if set
 	if configContext != nil {
 		rawConfig, err := kubeconfig.RawConfig()
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to get raw config from inline kubeconfig: %w", err)
 		}
 		rawConfig.CurrentContext = *configContext
+		overrides := &clientcmd.ConfigOverrides{
+			CurrentContext: *configContext,
+			Context:        clientcmdapi.Context{},
+		}
 		kubeconfig = clientcmd.NewNonInteractiveClientConfig(rawConfig, *configContext, overrides, nil)
 	}
 
@@ -572,15 +568,22 @@ func tryInlineKubeconfig(configPath string, configContext *string) (clientcmd.Cl
 }
 
 // pathOrContents checks if the given string is a file path or inline content.
-// If the value is a valid file path that exists on disk, it returns the expanded
-// path and isInline=false. Otherwise it returns the original value as inline
-// content with isInline=true.
+// It uses a positive YAML check (newlines + apiVersion key) to identify inline content,
+// and treats everything else as a file path — letting the standard loader handle
+// missing files and in-cluster fallback.
 // This follows the same pattern as the GCP plugin's pathOrContents function.
 func pathOrContents(poc string) (string, bool, error) {
 	if len(poc) == 0 {
 		return poc, false, nil
 	}
 
+	// Positive inline check: real kubeconfig YAML always has newlines and the apiVersion key;
+	// file path strings never will.
+	if strings.Contains(poc, "\n") && strings.Contains(poc, "apiVersion:") {
+		return poc, true, nil
+	}
+
+	// Treat as file path. Expand ~ if present.
 	path := poc
 	if path[0] == '~' {
 		var err error
@@ -590,18 +593,13 @@ func pathOrContents(poc string) (string, bool, error) {
 		}
 	}
 
-	// Check for valid file path
-	if _, err := os.Stat(path); err == nil {
-		return path, false, nil
+	// Surface real filesystem errors (e.g., permission denied), but let "not exist"
+	// fall through to the standard loader which handles its own fallback (e.g., in-cluster config).
+	if _, err := os.Stat(path); err != nil && !os.IsNotExist(err) {
+		return "", false, err
 	}
 
-	// If it looks like a file path but doesn't exist, return an error
-	if len(path) > 1 && (path[0] == '/' || path[0] == '\\') {
-		return "", false, fmt.Errorf("config_path: %s: no such file or directory", path)
-	}
-
-	// Otherwise, treat as inline content
-	return poc, true, nil
+	return path, false, nil
 }
 
 //// HYDRATE FUNCTIONS

--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -364,6 +364,16 @@ func getK8Config(ctx context.Context, d *plugin.QueryData) (clientcmd.ClientConf
 		return nil, nil
 	}
 
+	// If config_path contains inline kubeconfig YAML (not a file path), parse it directly without any disk I/O.
+	if kubernetesConfig.ConfigPath != nil {
+		if kubeconfig, ok, err := tryInlineKubeconfig(*kubernetesConfig.ConfigPath, kubernetesConfig.ConfigContext); err != nil {
+			return nil, err
+		} else if ok {
+			d.ConnectionManager.Cache.Set(cacheKey, kubeconfig)
+			return kubeconfig, nil
+		}
+	}
+
 	// Set default loader and overriding rules
 	loader := &clientcmd.ClientConfigLoadingRules{}
 	overrides := &clientcmd.ConfigOverrides{}
@@ -452,6 +462,19 @@ func getK8ConfigRaw(ctx context.Context, cc *connection.ConnectionCache, c *plug
 		return nil, nil
 	}
 
+	// If config_path contains inline kubeconfig YAML (not a file path), parse it directly without any disk I/O.
+	if kubernetesConfig.ConfigPath != nil {
+		if kubeconfig, ok, err := tryInlineKubeconfig(*kubernetesConfig.ConfigPath, kubernetesConfig.ConfigContext); err != nil {
+			return nil, err
+		} else if ok {
+			cacheErr := cc.Set(ctx, cacheKey, kubeconfig)
+			if cacheErr != nil {
+				logger.Error("getK8ConfigRaw", "cache-set", cacheErr)
+			}
+			return kubeconfig, nil
+		}
+	}
+
 	// Set default loader and overriding rules
 	loader := &clientcmd.ClientConfigLoadingRules{}
 	overrides := &clientcmd.ConfigOverrides{}
@@ -509,6 +532,76 @@ func getK8ConfigRaw(ctx context.Context, cc *connection.ConnectionCache, c *plug
 	}
 
 	return kubeconfig, nil
+}
+
+// tryInlineKubeconfig checks if configPath is inline YAML content (not a file path) using the pathOrContents.
+// If inline, it parses the content directly and returns the ClientConfig.
+// Returns ok=false if the value is a file path (caller should fall through to the standard loader).
+func tryInlineKubeconfig(configPath string, configContext *string) (clientcmd.ClientConfig, bool, error) {
+	_, isInline, err := pathOrContents(configPath)
+	if err != nil {
+		return nil, false, err
+	}
+	if !isInline {
+		return nil, false, nil
+	}
+
+	// Inline kubeconfig YAML — parse directly, zero disk I/O
+	overrides := &clientcmd.ConfigOverrides{}
+	if configContext != nil {
+		overrides.CurrentContext = *configContext
+		overrides.Context = clientcmdapi.Context{}
+	}
+
+	kubeconfig, err := clientcmd.NewClientConfigFromBytes([]byte(configPath))
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to parse inline kubeconfig from config_path: %w", err)
+	}
+
+	// Apply context override if set
+	if configContext != nil {
+		rawConfig, err := kubeconfig.RawConfig()
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to get raw config from inline kubeconfig: %w", err)
+		}
+		rawConfig.CurrentContext = *configContext
+		kubeconfig = clientcmd.NewNonInteractiveClientConfig(rawConfig, *configContext, overrides, nil)
+	}
+
+	return kubeconfig, true, nil
+}
+
+// pathOrContents checks if the given string is a file path or inline content.
+// If the value is a valid file path that exists on disk, it returns the expanded
+// path and isInline=false. Otherwise it returns the original value as inline
+// content with isInline=true.
+// This follows the same pattern as the GCP plugin's pathOrContents function.
+func pathOrContents(poc string) (string, bool, error) {
+	if len(poc) == 0 {
+		return poc, false, nil
+	}
+
+	path := poc
+	if path[0] == '~' {
+		var err error
+		path, err = homedir.Expand(path)
+		if err != nil {
+			return "", false, err
+		}
+	}
+
+	// Check for valid file path
+	if _, err := os.Stat(path); err == nil {
+		return path, false, nil
+	}
+
+	// If it looks like a file path but doesn't exist, return an error
+	if len(path) > 1 && (path[0] == '/' || path[0] == '\\') {
+		return "", false, fmt.Errorf("config_path: %s: no such file or directory", path)
+	}
+
+	// Otherwise, treat as inline content
+	return poc, true, nil
 }
 
 //// HYDRATE FUNCTIONS


### PR DESCRIPTION
Issue: #353 

## Changes

**`kubernetes/utils.go`**

- Added `pathOrContents(poc string)` — mirrors GCP plugin's helper. Returns `isInline=true` if the value is not a path that exists on disk and doesn't look like an absolute path.
- Added `tryInlineKubeconfig(configPath string, configContext *string)` — if `config_path` is inline YAML, parses it directly via `clientcmd.NewClientConfigFromBytes` with optional context override. Returns `ok=false` to let the caller fall through to the standard file-loader path.
- Hooked both `getK8Config` and `getK8ConfigRaw` to call `tryInlineKubeconfig` before the existing `ClientConfigLoadingRules` loader, so file-path usage is fully backwards-compatible.

## Behaviour

| `config_path` value | Behaviour |
|---|---|
| `/home/user/.kube/config` (exists) | unchanged — loaded from file |
| `apiVersion: v1\nkind: Config\n...` (YAML string) | parsed inline, no disk I/O |
| `/tmp/missing` (absolute, missing) | error: `no such file or directory` |

## Testing

Verified end-to-end with EKS kubeconfig passed inline. Ran 10 concurrent queries across 2 EKS clusters, all of them passing correctly.

(Code written by Opus 4.6)