### PR TITLE
Add time_zone column to kubernetes_cronjob

### DIFF
--- a/docs/tables/kubernetes_cronjob.md
+++ b/docs/tables/kubernetes_cronjob.md
@@ -24,6 +24,7 @@ select
   uid,
   failed_jobs_history_limit,
   schedule,
+  time_zone,
   suspend
 from
   kubernetes_cronjob;
@@ -36,6 +37,7 @@ select
   uid,
   failed_jobs_history_limit,
   schedule,
+  time_zone,
   suspend
 from
   kubernetes_cronjob;

--- a/k8s-test/tests/kubernetes_cronjob/cronjob.yaml
+++ b/k8s-test/tests/kubernetes_cronjob/cronjob.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hello
 spec:
   schedule: "* * * * *"
+  timeZone: "Europe/Berlin"
   jobTemplate:
     spec:
       template:

--- a/kubernetes/table_kubernetes_cronjob.go
+++ b/kubernetes/table_kubernetes_cronjob.go
@@ -39,6 +39,12 @@ func tableKubernetesCronJob(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("Spec.Schedule"),
 			},
 			{
+				Name:        "time_zone",
+				Type:        proto.ColumnType_STRING,
+				Description: "The time zone name for the given schedule.",
+				Transform:   transform.FromField("Spec.TimeZone"),
+			},
+			{
 				Name:        "starting_deadline_seconds",
 				Type:        proto.ColumnType_INT,
 				Description: "Optional deadline in seconds for starting the job if it misses scheduledtime for any reason.",


### PR DESCRIPTION
This extends the `kubernetes_cronjob` schema to include a `time_zone` column representing the `spec.timeZone` field of CronJobs, stable since Kubernetes v1.27: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones

This allows to query based on `time_zone` when relevant.
