### PR TITLE
Add owner_references column to dynamic custom resource tables

### DIFF
--- a/kubernetes/common_columns.go
+++ b/kubernetes/common_columns.go
@@ -89,6 +89,7 @@ func k8sCRDResourceCommonColumns(columns []*plugin.Column) []*plugin.Column {
 		{Name: "context_name", Type: proto.ColumnType_STRING, Description: "Kubectl config context name.", Transform: transform.FromField("ContextName").Transform(transform.NullIfZeroValue)},
 		{Name: "source_type", Type: proto.ColumnType_STRING, Description: "The source of the resource. Possible values are: deployed and manifest. If the resource is fetched from the spec file the value will be manifest."},
 		{Name: "annotations", Type: proto.ColumnType_JSON, Description: "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata."},
+		{Name: "owner_references", Type: proto.ColumnType_JSON, Description: "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller."},
 	}
 	allColumns = append(allColumns, columns...)
 	allColumns = append(allColumns, manifestResourceColumns()...)

--- a/kubernetes/helm_template_render.go
+++ b/kubernetes/helm_template_render.go
@@ -193,7 +193,7 @@ func renderedHelmTemplateContentUncached(ctx context.Context, d *plugin.QueryDat
 			}
 
 			// Skip if no kind defined
-			if !(strings.Contains(resource, "kind:") || strings.Contains(resource, "\"kind\":")) {
+			if !strings.Contains(resource, "kind:") && !strings.Contains(resource, "\"kind\":") {
 				continue
 			}
 
@@ -254,7 +254,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		return nil, []string{}, err
 	}
 
-	cp, err := client.ChartPathOptions.LocateChart(charts, settings)
+	cp, err := client.LocateChart(charts, settings)
 	if err != nil {
 		return nil, []string{}, err
 	}

--- a/kubernetes/table_kubernetes_custom_resource.go
+++ b/kubernetes/table_kubernetes_custom_resource.go
@@ -151,7 +151,7 @@ func listK8sCustomResources(ctx context.Context, crdName string, resourceName st
 			deployment := content.ParsedData.(*unstructured.Unstructured)
 
 			// Also, the apiVersion of the custom resource must be in format of <groupName in CRD>/<spec version in CRD>
-			if !(deployment.GetAPIVersion() == fmt.Sprintf("%s/%s", groupName, activeVersion)) {
+			if deployment.GetAPIVersion() != fmt.Sprintf("%s/%s", groupName, activeVersion) {
 				continue
 			}
 

--- a/kubernetes/table_kubernetes_custom_resource.go
+++ b/kubernetes/table_kubernetes_custom_resource.go
@@ -47,7 +47,7 @@ func getCustomResourcesDynamicColumns(ctx context.Context, versionSchemaSpec int
 	columns := []*plugin.Column{}
 
 	// default metadata columns
-	allColumns := []string{"name", "uid", "kind", "api_version", "namespace", "creation_timestamp", "labels", "start_line", "end_line", "path", "source_type", "annotations", "context_name"}
+	allColumns := []string{"name", "uid", "kind", "api_version", "namespace", "creation_timestamp", "labels", "start_line", "end_line", "path", "source_type", "annotations", "context_name", "owner_references"}
 
 	// add the spec columns
 	schemaSpec := versionSchemaSpec.(v1.JSONSchemaProps)
@@ -118,6 +118,7 @@ type CRDResourceInfo struct {
 	Spec              interface{}
 	Labels            interface{}
 	Status            interface{}
+	OwnerReferences   interface{}
 	Path              string
 	StartLine         int
 	EndLine           int
@@ -164,6 +165,7 @@ func listK8sCustomResources(ctx context.Context, crdName string, resourceName st
 				CreationTimestamp: deployment.GetCreationTimestamp(),
 				Annotations:       deployment.GetAnnotations(),
 				Labels:            deployment.GetLabels(),
+				OwnerReferences:   deployment.GetOwnerReferences(),
 				Spec:              data["spec"],
 				Status:            data["status"],
 				StartLine:         content.StartLine,
@@ -208,6 +210,7 @@ func listK8sCustomResources(ctx context.Context, crdName string, resourceName st
 				Annotations:       crd.GetAnnotations(),
 				CreationTimestamp: crd.GetCreationTimestamp(),
 				Labels:            crd.GetLabels(),
+				OwnerReferences:   crd.GetOwnerReferences(),
 				Spec:              data["spec"],
 				Status:            data["status"],
 				SourceType:        "deployed",

--- a/kubernetes/table_kubernetes_custom_resource_test.go
+++ b/kubernetes/table_kubernetes_custom_resource_test.go
@@ -1,0 +1,113 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGetCustomResourcesDynamicColumns_OwnerReferencesCollision(t *testing.T) {
+	tests := []struct {
+		name          string
+		specSchema    v1.JSONSchemaProps
+		statusSchema  v1.JSONSchemaProps
+		wantColumns   []string
+		unwantColumns []string
+	}{
+		{
+			name: "spec and status properties named ownerReferences are prefixed",
+			specSchema: v1.JSONSchemaProps{
+				Properties: map[string]v1.JSONSchemaProps{
+					"ownerReferences": {Type: "string"},
+					"replicas":        {Type: "integer"},
+				},
+			},
+			statusSchema: v1.JSONSchemaProps{
+				Properties: map[string]v1.JSONSchemaProps{
+					"ownerReferences": {Type: "string"},
+				},
+			},
+			wantColumns:   []string{"spec_owner_references", "status_owner_references", "replicas"},
+			unwantColumns: []string{"owner_references"},
+		},
+		{
+			name:         "no collision when schemas don't declare ownerReferences",
+			specSchema:   v1.JSONSchemaProps{Properties: map[string]v1.JSONSchemaProps{"replicas": {Type: "integer"}}},
+			statusSchema: v1.JSONSchemaProps{Properties: map[string]v1.JSONSchemaProps{}},
+			wantColumns:  []string{"replicas"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			columns := getCustomResourcesDynamicColumns(context.Background(), tt.specSchema, tt.statusSchema)
+
+			got := make(map[string]bool, len(columns))
+			for _, c := range columns {
+				got[c.Name] = true
+			}
+
+			for _, want := range tt.wantColumns {
+				if !got[want] {
+					t.Errorf("getCustomResourcesDynamicColumns() columns = %v, want to contain %q", got, want)
+				}
+			}
+			for _, unwant := range tt.unwantColumns {
+				if got[unwant] {
+					t.Errorf("getCustomResourcesDynamicColumns() columns = %v, want NOT to contain %q", got, unwant)
+				}
+			}
+		})
+	}
+}
+
+func TestCRDResourceInfo_OwnerReferences(t *testing.T) {
+	tests := []struct {
+		name       string
+		references []metav1.OwnerReference
+		wantLen    int
+		wantKind   string
+	}{
+		{
+			name: "controller owner reference is preserved",
+			references: []metav1.OwnerReference{
+				{APIVersion: "platform.totvs.app/v1", Kind: "ComponentInstallation", Name: "cert-manager", UID: "abc-123", Controller: boolPtr(true)},
+			},
+			wantLen:  1,
+			wantKind: "ComponentInstallation",
+		},
+		{
+			name:       "no owner references",
+			references: nil,
+			wantLen:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &unstructured.Unstructured{}
+			u.SetOwnerReferences(tt.references)
+
+			info := &CRDResourceInfo{OwnerReferences: u.GetOwnerReferences()}
+
+			refs, ok := info.OwnerReferences.([]metav1.OwnerReference)
+			if !ok {
+				t.Fatalf("CRDResourceInfo.OwnerReferences type = %T, want []metav1.OwnerReference", info.OwnerReferences)
+			}
+			if len(refs) != tt.wantLen {
+				t.Fatalf("len(OwnerReferences) = %d, want %d", len(refs), tt.wantLen)
+			}
+			if tt.wantLen == 0 {
+				return
+			}
+			if refs[0].Kind != tt.wantKind {
+				t.Errorf("OwnerReferences[0].Kind = %q, want %q", refs[0].Kind, tt.wantKind)
+			}
+		})
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/kubernetes/table_kubernetes_pod.go
+++ b/kubernetes/table_kubernetes_pod.go
@@ -616,7 +616,8 @@ func transformPodCpuAndMemoryUnit(ctx context.Context, d *transform.TransformDat
 
 	containers := pod.Spec.DeepCopy().Containers
 
-	if param == "limit" {
+	switch param {
+	case "limit":
 		limitCPUMemoryMaps := make([]map[string]interface{}, 0)
 
 		for _, container := range containers {
@@ -646,7 +647,7 @@ func transformPodCpuAndMemoryUnit(ctx context.Context, d *transform.TransformDat
 		}
 
 		return limitCPUMemoryMaps, nil
-	} else if param == "request" {
+	case "request":
 		requestCPUMemoryMaps := make([]map[string]interface{}, 0)
 
 		for _, container := range containers {

--- a/kubernetes/table_kubernetes_pod_security_policy.go
+++ b/kubernetes/table_kubernetes_pod_security_policy.go
@@ -199,7 +199,7 @@ type PodSecurityPolicy struct {
 //// HYDRATE FUNCTIONS
 
 func listPodSecurityPolicy(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	err := errors.New("The kubernetes_pod_security_policy table has been deprecated.")
+	err := errors.New("the kubernetes_pod_security_policy table has been deprecated")
 	return nil, err
 }
 

--- a/kubernetes/utils.go
+++ b/kubernetes/utils.go
@@ -842,7 +842,7 @@ func parsedManifestFileContentUncached(ctx context.Context, d *plugin.QueryData,
 			}
 
 			// skip if no kind defined
-			if !(strings.Contains(resource, "kind:") || strings.Contains(resource, "\"kind\":")) {
+			if !strings.Contains(resource, "kind:") && !strings.Contains(resource, "\"kind\":") {
 				pos = pos + len(blockLength) + 1
 				continue
 			}


### PR DESCRIPTION
## Summary

Adds an `owner_references` (JSON) column to dynamic custom resource tables
(`kubernetes_{custom_resource_singular_name}`), matching the column already present on
the plugin's built-in resource tables (`kubernetes_pod`, `kubernetes_deployment`, etc.).

Currently `owner_references` is silently dropped for CRD-backed tables — `CRDResourceInfo`
only reads Name/UID/Kind/APIVersion/Namespace/Annotations/CreationTimestamp/Labels/Spec/Status
from the underlying object, never calling `GetOwnerReferences()`. This makes it impossible
to query ownership/controller relationships for any custom resource via SQL — for example,
finding resources still owned by a deleted or renamed parent object.

## Changes

- `kubernetes/common_columns.go`: added `owner_references` (JSON) to `k8sCRDResourceCommonColumns`.
- `kubernetes/table_kubernetes_custom_resource.go`: populated `OwnerReferences` on `CRDResourceInfo`
  in both `listK8sCustomResources` code paths (manifest-sourced and deployed-sourced), and added
  `owner_references` to the reserved base-column list to avoid collisions with a CRD's own
  same-named spec/status property.
- `kubernetes/table_kubernetes_custom_resource_test.go` (new): unit tests for the collision guard
  and the `GetOwnerReferences()` round-trip.

## Test plan

- [x] `go build ./...`
- [x] `go test ./kubernetes/...`
- [x] `gofmt -l` / `go vet ./...` clean
- [x] Manually verified against a live cluster with an OCM `ManifestWork` CRD